### PR TITLE
fix: revert package name to vrx_project11

### DIFF
--- a/vrx_project11/CMakeLists.txt
+++ b/vrx_project11/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8)
 
-project(vrx_marine_autonomy)
+project(vrx_project11)
 
 set(CMAKE_CXX_STANDARD 17)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/vrx_project11/launch/gazebo_sim_launch.py
+++ b/vrx_project11/launch/gazebo_sim_launch.py
@@ -11,7 +11,7 @@ def generate_launch_description():
         DeclareLaunchArgument(
             'urdf',
             default_value=PathJoinSubstitution([
-                FindPackageShare('vrx_marine_autonomy'),
+                FindPackageShare('vrx_project11'),
                 'urdf', 'wamv.urdf'
             ]),
             description='URDF file to use for the robot'),

--- a/vrx_project11/launch/generate_wamv_launch.py
+++ b/vrx_project11/launch/generate_wamv_launch.py
@@ -19,12 +19,12 @@ def generate_launch_description():
             ),
             launch_arguments={
                 'component_yaml': PathJoinSubstitution([
-                    FindPackageShare('vrx_marine_autonomy'),
+                    FindPackageShare('vrx_project11'),
                     'config', 'wamv_config', 'component_config.yaml'
                 ]),
                 'wamv_target': LaunchConfiguration('wamv_target'),
                 'alternative_macros_file': PathJoinSubstitution([
-                    FindPackageShare('vrx_marine_autonomy'),
+                    FindPackageShare('vrx_project11'),
                     'urdf', 'macros.xacro'
                 ]),
             }.items()

--- a/vrx_project11/launch/nav2_bringup_launch.py
+++ b/vrx_project11/launch/nav2_bringup_launch.py
@@ -34,7 +34,7 @@ from nav2_common.launch import ReplaceString, RewrittenYaml
 
 def generate_launch_description():
     # Get the launch directory
-    bringup_dir = get_package_share_directory('vrx_marine_autonomy')
+    bringup_dir = get_package_share_directory('vrx_project11')
     launch_dir = os.path.join(bringup_dir, 'launch')
 
     # Create the launch configuration variables

--- a/vrx_project11/launch/wamv_helm_launch.py
+++ b/vrx_project11/launch/wamv_helm_launch.py
@@ -10,7 +10,7 @@ def generate_launch_description():
 
     return LaunchDescription([
         LifecycleNode(
-            package='vrx_marine_autonomy',
+            package='vrx_project11',
             executable='wamv_helm',
             name='wamv_helm',
             namespace='',

--- a/vrx_project11/launch/wamv_launch.py
+++ b/vrx_project11/launch/wamv_launch.py
@@ -89,7 +89,7 @@ def generate_launch_description():
                         IncludeLaunchDescription(
                             PythonLaunchDescriptionSource(
                                 PathJoinSubstitution([
-                                    FindPackageShare('vrx_marine_autonomy'),
+                                    FindPackageShare('vrx_project11'),
                                     'launch',
                                     'wamv_helm_launch.py'
                                 ])

--- a/vrx_project11/launch/wamv_launch.py
+++ b/vrx_project11/launch/wamv_launch.py
@@ -35,7 +35,7 @@ def generate_launch_description():
                 PushROSNamespace(namespace),
                 SetParametersFromFile(
                     filename=PathJoinSubstitution([
-                        FindPackageShare('vrx_marine_autonomy'),
+                        FindPackageShare('vrx_project11'),
                         'config',
                         'wamv.yaml'
                     ])
@@ -107,7 +107,7 @@ def generate_launch_description():
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource(
                 PathJoinSubstitution([
-                    FindPackageShare('vrx_marine_autonomy'),
+                    FindPackageShare('vrx_project11'),
                     'launch',
                     'nav2_bringup_launch.py'
                 ])

--- a/vrx_project11/package.xml
+++ b/vrx_project11/package.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <package format="2">
-  <name>vrx_marine_autonomy</name>
+  <name>vrx_project11</name>
   <version>0.0.0</version>
-  <description>The vrx_marine_autonomy package</description>
+  <description>The vrx_project11 package</description>
 
   <maintainer email="roland@ccom.unh.edu">Roland Arsenault</maintainer>
 

--- a/vrx_project11/urdf/macros.xacro
+++ b/vrx_project11/urdf/macros.xacro
@@ -6,6 +6,6 @@
   <xacro:include filename="$(find wamv_gazebo)/urdf/macros.xacro" />
 
   <!-- Include extra sensor macros -->
-  <xacro:include filename="$(find vrx_marine_autonomy)/urdf/components/wamv_multibeam_sonar.xacro" />
+  <xacro:include filename="$(find vrx_project11)/urdf/components/wamv_multibeam_sonar.xacro" />
 
 </robot>


### PR DESCRIPTION
Reverts the package name from vrx_marine_autonomy to vrx_project11 to match directory structure.