### PR TITLE
fix: use ben/motion_sensor instead of non-existent ben/nav frame

### DIFF
--- a/asv_sim/config/ben.yaml
+++ b/asv_sim/config/ben.yaml
@@ -1,7 +1,7 @@
 asv_sim:
   ros__parameters:
     platforms.ben.model: cw4
-    platforms.ben.mru_frame: ben/nav
+    platforms.ben.mru_frame: ben/motion_sensor
 
     # Portsmouth, New Hampshire, cod rock
     platforms.ben.start_lat: 43.073397415457535


### PR DESCRIPTION
## Summary

- Change `platforms.ben.mru_frame` from `ben/nav` to `ben/motion_sensor` in `asv_sim/config/ben.yaml`
- `ben/nav` doesn't exist in the `ben_description` URDF, causing `mru_transform` to spam `canTransform` warnings
- `ben/motion_sensor` is the inertial reference frame all nav sensors are attached to

Closes #14

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
