### PR TITLE
fix: use marine/status/helm topic instead of stale marine_autonomy/ prefix

### DIFF
--- a/asv_helm/src/asv_helm_node.cpp
+++ b/asv_helm/src/asv_helm_node.cpp
@@ -28,7 +28,7 @@ public:
   {
     throttle_publisher_ = create_publisher<std_msgs::msg::Float32>("throttle",1);
     rudder_publisher_ = create_publisher<std_msgs::msg::Float32>("rudder",1);
-    status_publisher_ = create_publisher<marine_interfaces::msg::Heartbeat>("marine_autonomy/status/helm",1);
+    status_publisher_ = create_publisher<marine_interfaces::msg::Heartbeat>("marine/status/helm",1);
 
     helm_subscription_ = create_subscription<marine_interfaces::msg::Helm>("helm", 1, std::bind(&ASVHelm::helmCallback, this, std::placeholders::_1));
     twist_subscription_ = create_subscription<geometry_msgs::msg::TwistStamped>("cmd_vel", 10, std::bind(&ASVHelm::twistCallback, this, std::placeholders::_1));

--- a/vrx_project11/src/wamv_helm.cpp
+++ b/vrx_project11/src/wamv_helm.cpp
@@ -33,7 +33,7 @@ public:
     left_position_publisher_ = create_publisher<std_msgs::msg::Float64>("thrusters/left/pos",1);
     right_position_publisher_ = create_publisher<std_msgs::msg::Float64>("thrusters/right/pos",1);
 
-    status_publisher_ = create_publisher<marine_interfaces::msg::Heartbeat>("marine_autonomy/status/helm",1);
+    status_publisher_ = create_publisher<marine_interfaces::msg::Heartbeat>("marine/status/helm",1);
 
     twist_subscription_ = create_subscription<geometry_msgs::msg::TwistStamped>("cmd_vel", 10, std::bind(&WAMVHelm::twist_callback, this, std::placeholders::_1));
     joint_states_subscription_ = create_subscription<sensor_msgs::msg::JointState>("joint_states", 5, std::bind(&WAMVHelm::joint_states_callback, this, std::placeholders::_1));


### PR DESCRIPTION
## Summary

- Fix heartbeat topic mismatch: change `marine_autonomy/status/helm` to `marine/status/helm` in ASV Helm and WAMV Helm
- This allows heartbeat messages to reach Helm Manager and CAMP

## Files Changed

- `asv_helm/src/asv_helm_node.cpp` — line 31
- `vrx_project11/src/wamv_helm.cpp` — line 36

## Test Plan

- [ ] `ros2 topic hz /ben/marine/status/helm` shows ~20 Hz (was 0)
- [ ] `ros2 topic hz /ben/marine/heartbeat` shows ~20 Hz (was 0)
- [ ] `ros2 topic echo /ben/marine/heartbeat --once` shows `piloting_mode` key

Closes #16

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`