### PR TITLE
Migrate multibeam sonar to bathymetric_multibeam_sonar plugin

### DIFF
--- a/vrx_project11/config/wamv_config/component_config.xacro
+++ b/vrx_project11/config/wamv_config/component_config.xacro
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro" name="wam-v-components">
+  <xacro:macro name="yaml_components">
+    <!-- === wamv_camera === -->
+      <xacro:wamv_camera name="front_camera" visualize="False" x="0.75" y="0.0" z="1.5" R="0.0" P="${radians(15)}" Y="0.0" post_Y="0.0" />
+      <xacro:wamv_camera name="left_camera" visualize="False" x="0.65" y="0.4" z="1.5" R="0.0" P="${radians(15)}" Y="${radians(65)}" post_Y="0.0" />
+      <xacro:wamv_camera name="right_camera" visualize="False" x="0.65" y="-0.4" z="1.5" R="0.0" P="${radians(15)}" Y="${radians(-65)}" post_Y="0.0" />
+
+    <!-- === wamv_gps === -->
+      <xacro:wamv_gps name="gps_wamv" x="-0.85" y="0.0" z="1.3" R="0.0" P="0.0" Y="0.0" />
+
+    <!-- === wamv_imu === -->
+      <xacro:wamv_imu name="imu_wamv" x="0.3" y="-0.2" z="1.3" R="0.0" P="0.0" Y="0.0" />
+
+    <!-- === lidar === -->
+      <xacro:lidar name="lidar_wamv" type="16_beam" x="0.7" y="0.0" z="1.8" R="0.0" P="${radians(8)}" Y="0.0" post_Y="0.0" />
+
+    <!-- === wamv_ball_shooter === -->
+      <xacro:wamv_ball_shooter name="ball_shooter" x="0.55" y="-0.3" z="1.3" pitch="${radians(-20)}" yaw="0.0" />
+
+    <!-- === wamv_pinger === -->
+      <xacro:wamv_pinger sensor_name="receiver" position="1.0 0 -1.0" />
+
+    <!-- === wamv_bathymetric_multibeam_sonar === -->
+      <xacro:wamv_bathymetric_multibeam_sonar name="bathymetric_multibeam_sonar" x="0.0" y="0.0" z="-0.3" R="0.0" P="${radians(90.0)}" Y="0.0" update_rate="2.0" beam_count="256" range_min="0.5" range_max="50.0" angle_min="${radians(-60)}" angle_max="${radians(60)}" sonar_frequency="200000.0" sound_speed="1500.0" />
+
+  </xacro:macro>
+</robot>

--- a/vrx_project11/config/wamv_config/component_config.yaml
+++ b/vrx_project11/config/wamv_config/component_config.yaml
@@ -62,8 +62,8 @@ wamv_ball_shooter:
 wamv_pinger:
     - sensor_name: receiver
       position: 1.0 0 -1.0
-wamv_multibeam_sonar:
-    - name: multibeam_sonar
+wamv_bathymetric_multibeam_sonar:
+    - name: bathymetric_multibeam_sonar
       x: 0.0
       y: 0.0
       z: -0.3

--- a/vrx_project11/config/wamv_config/thruster_config.yaml
+++ b/vrx_project11/config/wamv_config/thruster_config.yaml
@@ -1,0 +1,7 @@
+engine:
+  - prefix: "left"
+    position: "-2.373776 1.027135 0.318237"
+    orientation: "0.0 0.0 0.0"
+  - prefix: "right"
+    position: "-2.373776 -1.027135 0.318237"
+    orientation: "0.0 0.0 0.0"

--- a/vrx_project11/urdf/components/wamv_bathymetric_multibeam_sonar.xacro
+++ b/vrx_project11/urdf/components/wamv_bathymetric_multibeam_sonar.xacro
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro" xmlns:gz="http://gazebosim.org/schema">
+  <!-- Macro to insert a Multibeam Echosounder ROS integration
+    name: Prefix used for naming.
+    x: X position of the sonar (from the base_link).
+    y: Y position of the sonar (from the base_link).
+    z: Z position of the sonar (from the base_link).
+    R: Roll orientation of the sonar (from the sonar's origin).
+    P: Pitch orientation of the sonar (from the sonar's origin).
+    Y: Yaw orientation of the sonar (from the sonar's origin).
+    post_Y: Yaw orientation of the post (from the post's origin).
+    post_z_from: Z position of the post's base.
+    update_rate: frequency to publish output, hz
+  -->
+  <xacro:macro name="wamv_bathymetric_multibeam_sonar" params="name
+                                            x:=0.0 y:=0 z:=0.0
+                                            R:=0 P:=${radians(90)} Y:=0
+                                            post_Y:=0 post_z_from:=1.2965
+                                            update_rate:=2
+                                            beam_count:=256
+                                            range_min:=0.5
+                                            range_max:=50.0
+                                            angle_min:=${radians(-60)}
+                                            angle_max:=${radians(60)}
+                                            sonar_frequency:=200000.0
+                                            sound_speed:=1500.0">
+    <!-- Define length variables for link positioning -->
+    <xacro:property name="platform_z" value="${post_z_from}"/>
+    <xacro:property name="post_to_post_arm_x" value="0.03"/>
+    <xacro:property name="post_arm_to_sonar_x" value="0.04"/>
+    <xacro:property name="post_arm_to_sonar_z" value="0.05"/>
+
+    <!-- multibeam sonar sensor -->
+    <link name="${namespace}/${name}_link">
+      <visual>
+        <origin xyz="0 0 0.0" rpy="0 0 0"/>
+        <geometry>
+          <box size="0.1 0.2 0.2"/>
+        </geometry>
+      </visual>
+      <collision name="${name}_collision">
+        <geometry>
+          <box size="0.1 0.2 0.2"/>
+        </geometry>
+      </collision>
+      <inertial>
+        <mass value="1"/>
+        <inertia
+          ixx="0.00109375"
+          iyy="0.00109375"
+          izz="0.00125"
+          ixy="0"
+          ixz="0"
+          iyz="0"/>
+      </inertial>
+    </link>
+
+    <!-- Define post length and mass based on desired z position of sensor -->
+    <xacro:property name="post_length" value="${platform_z-z-post_arm_to_sonar_z}"/>
+    <xacro:property name="post_mass_per_meter" value="0.9"/>
+    <xacro:property name="post_mass" value="${post_mass_per_meter * post_length}"/>
+    <xacro:property name="post_radius" value="0.0076"/>
+
+    <!-- Sensor post -->
+    <link name="${namespace}/${name}_post_link">
+      <visual>
+        <geometry>
+          <cylinder radius="${post_radius}" length="${post_length}"/>
+        </geometry>
+        <material name="${name}_post_material">
+          <color rgba="0.0 0.0 0.0 1.0"/>
+        </material>
+      </visual>
+      <collision name="${name}_post_collision">
+        <geometry>
+          <cylinder radius="${post_radius}" length="${post_length}"/>
+        </geometry>
+      </collision>
+      <inertial>
+        <mass value="${post_mass}"/>
+        <inertia
+          ixx="${(post_mass/12) * (3*post_radius*post_radius + post_length*post_length)}"
+          iyy="${(post_mass/12) * (3*post_radius*post_radius + post_length*post_length)}"
+          izz="${(post_mass/2) * (post_radius*post_radius)}"
+          ixy="0"
+          ixz="0"
+          iyz="0"/>
+      </inertial>
+    </link>
+
+    <!-- Sensor post arm -->
+    <link name="${namespace}/${name}_post_arm_link">
+      <visual name="${name}_post_arm_visual">
+        <origin xyz="-0.038 0 -0.003" rpy="${radians(-60)} 0 ${-pi/2}"/>
+        <geometry>
+          <mesh filename="package://vrx_gazebo/models/sensor_post/mesh/sensor_post_arm.dae"/>
+        </geometry>
+      </visual>
+      <collision name="${name}_post_arm_collision">
+        <origin xyz="0 0 0" rpy="${radians(-60)-pi/20} 0 ${-pi/2}"/>
+        <geometry>
+          <cylinder radius="0.008" length="0.065"/>
+        </geometry>
+      </collision>
+      <inertial>
+        <origin xyz="0 0 0" rpy="${radians(-60)-pi/20} 0 ${-pi/2}"/>
+        <mass value="0.1"/>
+        <inertia
+          ixx="0.00003680833"
+          iyy="0.00003680833"
+          izz="0.00000320000"
+          ixy="0"
+          ixz="0"
+          iyz="0"/>
+      </inertial>
+    </link>
+
+    <!-- Base to sensor post joint -->
+    <xacro:property name="post_z" value="${platform_z-post_length/2}"/>
+    <xacro:property name="post_to_sonar_x" value="${post_to_post_arm_x+post_arm_to_sonar_x}"/>
+    <joint name="${namespace}/base_to_${name}_post_joint" type="fixed">
+      <origin xyz="${x-(post_to_sonar_x)*cos(post_Y)} ${y-(post_to_sonar_x)*sin(post_Y)} ${post_z}" rpy="0 0 ${post_Y}" />
+      <parent link="${namespace}/base_link" />
+      <child link="${namespace}/${name}_post_link" />
+    </joint>
+
+    <!-- Sensor post to sensor post arm joint -->
+    <joint name="${namespace}/${name}_post_to_${name}_post_arm_joint" type="fixed">
+      <origin xyz="${post_to_post_arm_x} 0 ${z-post_z-post_arm_to_sonar_z}" rpy="0 0 0" />
+      <parent link="${namespace}/${name}_post_link" />
+      <child link="${namespace}/${name}_post_arm_link" />
+    </joint>
+
+    <!-- Sensor post arm to sonar joint -->
+    <joint name="${namespace}/${name}_post_arm_to_${name}_joint" type="fixed">
+      <origin xyz="${post_arm_to_sonar_x} 0 ${post_arm_to_sonar_z}" rpy="${R} ${P} ${Y-post_Y}" />
+      <parent link="${namespace}/${name}_post_arm_link" />
+      <child link="${namespace}/${name}_link" />
+    </joint>
+
+    <gazebo reference="${namespace}/${name}_link">
+      <visual>
+        <material>
+          <diffuse>1.0 1.0 1.0</diffuse>
+          <specular>1.0 1.0 1.0</specular>
+          <pbr>
+            <metal>
+              <albedo_map>model://vrx_gazebo/models/3d_lidar/mesh/3d_Lidar_Albedo.png</albedo_map>
+              <normal_map>model://vrx_gazebo/models/3d_lidar/mesh/3d_Lidar_Normal.png</normal_map>
+              <roughness_map>model://vrx_gazebo/models/3d_lidar/mesh/3d_Lidar_Roughness.png</roughness_map>
+              <metalness_map>model://vrx_gazebo/models/3d_lidar/mesh/3d_Lidar_Metalness.png</metalness_map>
+            </metal>
+          </pbr>
+        </material>
+      </visual>
+    </gazebo>
+
+    <gazebo>
+      <plugin
+        filename="bathymetric_multibeam_sonar_system"
+        name="custom::BathymetricMultibeamSonarSystem">
+      </plugin>
+    </gazebo>
+
+    <gazebo reference="${namespace}/${name}_link">
+      <sensor type="custom" name="${name}_sensor" gz:type="bathymetric_multibeam_sonar">
+        <always_on>true</always_on>
+        <update_rate>${update_rate}</update_rate>
+        <topic>${namespace}/${name}/sonar_data</topic>
+        <visualize>true</visualize>
+        <gz:bathymetric_multibeam_sonar>
+          <frequency>${sonar_frequency}</frequency>
+          <sound_speed>${sound_speed}</sound_speed>
+          <minimum_range>${range_min}</minimum_range>
+          <maximum_range>${range_max}</maximum_range>
+          <beam_count>${beam_count}</beam_count>
+          <minimum_beam_angle>${angle_min}</minimum_beam_angle>
+          <maximum_beam_angle>${angle_max}</maximum_beam_angle>
+        </gz:bathymetric_multibeam_sonar>
+      </sensor>
+    </gazebo>
+
+  </xacro:macro>
+</robot>

--- a/vrx_project11/urdf/macros.xacro
+++ b/vrx_project11/urdf/macros.xacro
@@ -7,5 +7,6 @@
 
   <!-- Include extra sensor macros -->
   <xacro:include filename="$(find vrx_project11)/urdf/components/wamv_multibeam_sonar.xacro" />
+  <xacro:include filename="$(find vrx_project11)/urdf/components/wamv_bathymetric_multibeam_sonar.xacro" />
 
 </robot>

--- a/vrx_project11/urdf/wamv.urdf
+++ b/vrx_project11/urdf/wamv.urdf
@@ -497,7 +497,7 @@
       <nRR>800.0</nRR>
     </plugin>
   </gazebo>
-  <!-- === [Un]lock the robot to the world === -->
+  <!-- === [Un]lock the robot to the world ===
   <gazebo>
     <plugin filename="gz-sim-detachable-joint-system" name="gz::sim::systems::DetachableJoint">
       <parent_link>wamv/base_link</parent_link>
@@ -506,7 +506,7 @@
       <topic>/vrx/release</topic>
       <suppress_child_warning>true</suppress_child_warning>
     </plugin>
-  </gazebo>
+  </gazebo> -->
   <!-- === TF === -->
   <!-- Publish robot state information -->
   <gazebo>
@@ -1347,14 +1347,14 @@
     </plugin>
   </gazebo>
   <!-- multibeam sonar sensor -->
-  <link name="wamv/multibeam_sonar_link">
+  <link name="wamv/bathymetric_multibeam_sonar_link">
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0.0"/>
       <geometry>
         <box size="0.1 0.2 0.2"/>
       </geometry>
     </visual>
-    <collision name="multibeam_sonar_collision">
+    <collision name="bathymetric_multibeam_sonar_collision">
       <geometry>
         <box size="0.1 0.2 0.2"/>
       </geometry>
@@ -1365,16 +1365,16 @@
     </inertial>
   </link>
   <!-- Sensor post -->
-  <link name="wamv/multibeam_sonar_post_link">
+  <link name="wamv/bathymetric_multibeam_sonar_post_link">
     <visual>
       <geometry>
         <cylinder length="1.5465" radius="0.0076"/>
       </geometry>
-      <material name="multibeam_sonar_post_material">
+      <material name="bathymetric_multibeam_sonar_post_material">
         <color rgba="0.0 0.0 0.0 1.0"/>
       </material>
     </visual>
-    <collision name="multibeam_sonar_post_collision">
+    <collision name="bathymetric_multibeam_sonar_post_collision">
       <geometry>
         <cylinder length="1.5465" radius="0.0076"/>
       </geometry>
@@ -1385,14 +1385,14 @@
     </inertial>
   </link>
   <!-- Sensor post arm -->
-  <link name="wamv/multibeam_sonar_post_arm_link">
-    <visual name="multibeam_sonar_post_arm_visual">
+  <link name="wamv/bathymetric_multibeam_sonar_post_arm_link">
+    <visual name="bathymetric_multibeam_sonar_post_arm_visual">
       <origin rpy="-1.0471975511965976 0 -1.5707963267948966" xyz="-0.038 0 -0.003"/>
       <geometry>
         <mesh filename="package://vrx_gazebo/models/sensor_post/mesh/sensor_post_arm.dae"/>
       </geometry>
     </visual>
-    <collision name="multibeam_sonar_post_arm_collision">
+    <collision name="bathymetric_multibeam_sonar_post_arm_collision">
       <origin rpy="-1.2042771838760873 0 -1.5707963267948966" xyz="0 0 0"/>
       <geometry>
         <cylinder length="0.065" radius="0.008"/>
@@ -1404,24 +1404,24 @@
       <inertia ixx="0.00003680833" ixy="0" ixz="0" iyy="0.00003680833" iyz="0" izz="0.00000320000"/>
     </inertial>
   </link>
-  <joint name="wamv/base_to_multibeam_sonar_post_joint" type="fixed">
+  <joint name="wamv/base_to_bathymetric_multibeam_sonar_post_joint" type="fixed">
     <origin rpy="0 0 0" xyz="-0.07 0.0 0.52325"/>
     <parent link="wamv/base_link"/>
-    <child link="wamv/multibeam_sonar_post_link"/>
+    <child link="wamv/bathymetric_multibeam_sonar_post_link"/>
   </joint>
   <!-- Sensor post to sensor post arm joint -->
-  <joint name="wamv/multibeam_sonar_post_to_multibeam_sonar_post_arm_joint" type="fixed">
+  <joint name="wamv/bathymetric_multibeam_sonar_post_to_bathymetric_multibeam_sonar_post_arm_joint" type="fixed">
     <origin rpy="0 0 0" xyz="0.03 0 -0.8732500000000001"/>
-    <parent link="wamv/multibeam_sonar_post_link"/>
-    <child link="wamv/multibeam_sonar_post_arm_link"/>
+    <parent link="wamv/bathymetric_multibeam_sonar_post_link"/>
+    <child link="wamv/bathymetric_multibeam_sonar_post_arm_link"/>
   </joint>
   <!-- Sensor post arm to sonar joint -->
-  <joint name="wamv/multibeam_sonar_post_arm_to_multibeam_sonar_joint" type="fixed">
+  <joint name="wamv/bathymetric_multibeam_sonar_post_arm_to_bathymetric_multibeam_sonar_joint" type="fixed">
     <origin rpy="0.0 1.5707963267948966 0.0" xyz="0.04 0 0.05"/>
-    <parent link="wamv/multibeam_sonar_post_arm_link"/>
-    <child link="wamv/multibeam_sonar_link"/>
+    <parent link="wamv/bathymetric_multibeam_sonar_post_arm_link"/>
+    <child link="wamv/bathymetric_multibeam_sonar_link"/>
   </joint>
-  <gazebo reference="wamv/multibeam_sonar_link">
+  <gazebo reference="wamv/bathymetric_multibeam_sonar_link">
     <visual>
       <material>
         <diffuse>1.0 1.0 1.0</diffuse>
@@ -1438,56 +1438,24 @@
     </visual>
   </gazebo>
   <gazebo>
-    <plugin filename="multibeam_sonar_system" name="custom::MultibeamSonarSystem">
+    <plugin filename="bathymetric_multibeam_sonar_system" name="custom::BathymetricMultibeamSonarSystem">
       </plugin>
   </gazebo>
-  <gazebo reference="wamv/multibeam_sonar_link">
-    <sensor gz:type="multibeam_sonar" name="multibeam_sonar_sensor" type="custom">
+  <gazebo reference="wamv/bathymetric_multibeam_sonar_link">
+    <sensor gz:type="bathymetric_multibeam_sonar" name="bathymetric_multibeam_sonar_sensor" type="custom">
       <always_on>true</always_on>
       <update_rate>2.0</update_rate>
-      <topic>wamv/multibeam_sonar/sonar_data</topic>
-      <gz_frame_id>wamv/wamv/multibeam_sonar_link</gz_frame_id>
+      <topic>wamv/bathymetric_multibeam_sonar/sonar_data</topic>
       <visualize>true</visualize>
-      <gz:multibeam_sonar>
-        <ray degrees="false">
-          <scan>
-            <horizontal>
-              <beams>256</beams>
-              <min_angle>-1.0471975511965976</min_angle>
-              <max_angle>1.0471975511965976</max_angle>
-            </horizontal>
-            <vertical>
-              <rays>30</rays>
-              <min_angle>-0.0349</min_angle>
-              <max_angle>0.0349</max_angle>
-            </vertical>
-          </scan>
-          <range>
-            <min>0.5</min>
-            <max>50.0</max>
-          </range>
-        </ray>
-        <spec>
-          <!-- Sonar properties -->
-          <verticalFOV>0.03490658503988659</verticalFOV>
-          <sonarFreq>200000.0</sonarFreq>
-          <bandwidth>29.9e3</bandwidth>
-          <soundSpeed>1500.0</soundSpeed>
-          <sourceLevel>220</sourceLevel>
-          <maxDistance>50.0</maxDistance>
-          <raySkips>3</raySkips>
-          <sensorGain>0.02</sensorGain>
-          <blazingSonarImage>true</blazingSonarImage>
-          <writeLog>false</writeLog>
-          <debugFlag>false</debugFlag>
-          <writeFrameInterval>5</writeFrameInterval>
-          <!-- ROS publication topics -->
-          <pointCloudTopicName>point_cloud</pointCloudTopicName>
-          <sonarImageRawTopicName>sonar_image_raw</sonarImageRawTopicName>
-          <sonarImageTopicName>sonar_image</sonarImageTopicName>
-          <frameName>wamv/multibeam_sonar_link</frameName>
-        </spec>
-      </gz:multibeam_sonar>
+      <gz:bathymetric_multibeam_sonar>
+        <frequency>200000.0</frequency>
+        <sound_speed>1500.0</sound_speed>
+        <minimum_range>0.5</minimum_range>
+        <maximum_range>50.0</maximum_range>
+        <beam_count>256</beam_count>
+        <minimum_beam_angle>-1.0471975511965976</minimum_beam_angle>
+        <maximum_beam_angle>1.0471975511965976</maximum_beam_angle>
+      </gz:bathymetric_multibeam_sonar>
     </sensor>
   </gazebo>
   <link name="wamv/cpu_cases_link">


### PR DESCRIPTION
## Summary

Uncommitted local changes from the old `project11_simulation` workspace, found during migration to `ros2_agent_workspace`.

- Rename `multibeam_sonar` → `bathymetric_multibeam_sonar` throughout (links, joints, plugins, sensor type, xacro macro)
- Switch from `MultibeamSonarSystem` to `BathymetricMultibeamSonarSystem` Gazebo plugin with simplified config
- Add new `wamv_bathymetric_multibeam_sonar` xacro macro alongside the existing one
- Add `component_config.xacro` (xacro version of component config) and `thruster_config.yaml`
- Comment out DetachableJoint plugin (frees WAM-V immediately for testing)

## Investigation needed before merging

- The upstream `jazzy` branch still uses the old `multibeam_sonar` naming and plugin. This branch represents a migration to a newer Gazebo plugin — verify the `BathymetricMultibeamSonarSystem` plugin is available in the target DAVE/Gazebo environment.
- The DetachableJoint was commented out — determine if this was intentional for production or just for testing convenience.
- Companion change: Santorini seafloor model added in `rolker/vrx` branch `add-santorini-seafloor` for sonar testing.
- This branch likely has merge conflicts with `jazzy` since it was based on a pre-rename commit history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)