### PR TITLE
Unify coordinate system to ECEF-based ENU

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 *.pyc
+build/
+install/
+log/
 doc/html
 doc/manifest.yaml
 

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/coordinates.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/coordinates.py
@@ -1,0 +1,262 @@
+# Copyright 2025 Roland Arsenault
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared coordinate transformations between WGS84 and local ENU.
+
+All conversions use ECEF as the intermediate frame, via
+``marine_autonomy.wgs84``, to avoid the cosine-approximation errors
+that accumulate over large bounding boxes.
+"""
+
+import math
+
+import numpy as np
+from marine_autonomy.wgs84 import (
+    toECEFfromDegrees,
+    fromECEFtoLatLongDegrees,
+)
+from osgeo import ogr
+
+# WGS84 ellipsoid constants (same as marine_autonomy.wgs84)
+_A = 6378137.0
+_E2 = 0.006694380004260814
+
+
+def latlon_to_enu(lat, lon, ref_lat, ref_lon):
+    """Convert WGS84 lat/lon to local ENU meters via ECEF.
+
+    Args:
+        lat: Latitude in degrees.
+        lon: Longitude in degrees.
+        ref_lat: Reference (origin) latitude in degrees.
+        ref_lon: Reference (origin) longitude in degrees.
+
+    Returns:
+        (east, north) in meters relative to the reference point.
+    """
+    rx, ry, rz = toECEFfromDegrees(ref_lat, ref_lon)
+    px, py, pz = toECEFfromDegrees(lat, lon)
+    dx, dy, dz = px - rx, py - ry, pz - rz
+    lat_r = math.radians(ref_lat)
+    lon_r = math.radians(ref_lon)
+    sin_lat = math.sin(lat_r)
+    cos_lat = math.cos(lat_r)
+    sin_lon = math.sin(lon_r)
+    cos_lon = math.cos(lon_r)
+    east = -sin_lon * dx + cos_lon * dy
+    north = (-sin_lat * cos_lon * dx
+             - sin_lat * sin_lon * dy
+             + cos_lat * dz)
+    return east, north
+
+
+def latlon_to_enu_array(lats, lons, ref_lat, ref_lon):
+    """Vectorized conversion of WGS84 lat/lon arrays to local ENU meters.
+
+    Args:
+        lats: numpy array of latitudes in degrees.
+        lons: numpy array of longitudes in degrees.
+        ref_lat: Reference latitude in degrees.
+        ref_lon: Reference longitude in degrees.
+
+    Returns:
+        (east, north) numpy arrays in meters.
+    """
+    lats_r = np.radians(lats)
+    lons_r = np.radians(lons)
+    ref_lat_r = math.radians(ref_lat)
+    ref_lon_r = math.radians(ref_lon)
+
+    # Transverse radius of curvature
+    sin_lat = np.sin(lats_r)
+    n = _A / np.sqrt(1 - _E2 * sin_lat ** 2)
+
+    # ECEF for query points
+    cos_lat = np.cos(lats_r)
+    cos_lon = np.cos(lons_r)
+    sin_lon = np.sin(lons_r)
+    px = n * cos_lat * cos_lon
+    py = n * cos_lat * sin_lon
+    pz = n * (1 - _E2) * sin_lat
+
+    # ECEF for reference point
+    rx, ry, rz = toECEFfromDegrees(ref_lat, ref_lon)
+
+    dx = px - rx
+    dy = py - ry
+    dz = pz - rz
+
+    # Rotation to ENU
+    sin_ref_lat = math.sin(ref_lat_r)
+    cos_ref_lat = math.cos(ref_lat_r)
+    sin_ref_lon = math.sin(ref_lon_r)
+    cos_ref_lon = math.cos(ref_lon_r)
+
+    east = -sin_ref_lon * dx + cos_ref_lon * dy
+    north = (-sin_ref_lat * cos_ref_lon * dx
+             - sin_ref_lat * sin_ref_lon * dy
+             + cos_ref_lat * dz)
+    return east, north
+
+
+def enu_to_latlon(east, north, ref_lat, ref_lon):
+    """Convert local ENU meters back to WGS84 lat/lon via ECEF.
+
+    Args:
+        east: Easting in meters.
+        north: Northing in meters.
+        ref_lat: Reference latitude in degrees.
+        ref_lon: Reference longitude in degrees.
+
+    Returns:
+        (lat, lon) in degrees.
+    """
+    rx, ry, rz = toECEFfromDegrees(ref_lat, ref_lon)
+    lat_r = math.radians(ref_lat)
+    lon_r = math.radians(ref_lon)
+    sin_lat = math.sin(lat_r)
+    cos_lat = math.cos(lat_r)
+    sin_lon = math.sin(lon_r)
+    cos_lon = math.cos(lon_r)
+
+    # ENU to ECEF delta (inverse of the rotation matrix)
+    # up = 0 (stay on surface)
+    dx = (-sin_lon * east
+          - sin_lat * cos_lon * north)
+    dy = (cos_lon * east
+          - sin_lat * sin_lon * north)
+    dz = cos_lat * north
+
+    lat, lon, _ = fromECEFtoLatLongDegrees(rx + dx, ry + dy, rz + dz)
+    return lat, lon
+
+
+def enu_to_latlon_array(east, north, ref_lat, ref_lon):
+    """Vectorized conversion of ENU meters to WGS84 lat/lon.
+
+    Args:
+        east: numpy array of easting values in meters.
+        north: numpy array of northing values in meters.
+        ref_lat: Reference latitude in degrees.
+        ref_lon: Reference longitude in degrees.
+
+    Returns:
+        (lats, lons) numpy arrays in degrees.
+    """
+    rx, ry, rz = toECEFfromDegrees(ref_lat, ref_lon)
+    lat_r = math.radians(ref_lat)
+    lon_r = math.radians(ref_lon)
+    sin_lat = math.sin(lat_r)
+    cos_lat = math.cos(lat_r)
+    sin_lon = math.sin(lon_r)
+    cos_lon = math.cos(lon_r)
+
+    # ENU to ECEF delta
+    dx = -sin_lon * east - sin_lat * cos_lon * north
+    dy = cos_lon * east - sin_lat * sin_lon * north
+    dz = cos_lat * north
+
+    # ECEF coordinates
+    ex = rx + dx
+    ey = ry + dy
+    ez = rz + dz
+
+    # Vectorized ECEF to lat/lon (Bowring's iterative method simplified)
+    r = np.sqrt(ex ** 2 + ey ** 2)
+    lon_out = np.degrees(np.arctan2(ey, ex))
+
+    # Use the same closed-form as wgs84.fromECEFtoLatLong but vectorized
+    b = 6356752.3142
+    ep2 = (_A * _A) / (b * b) - 1.0
+    E2_val = _A * _A - b * b
+    F = 54 * b * b * ez * ez
+    G = r * r + (1 - _E2) * ez * ez - _E2 * E2_val
+    C = (_E2 * _E2 * F * r * r) / (G ** 3)
+    s = np.cbrt(1 + C + np.sqrt(C * C + 2 * C))
+    P = F / (3 * (s + 1.0 / s + 1) ** 2 * G * G)
+    Q = np.sqrt(1 + 2 * _E2 * _E2 * P)
+    r0 = (-(P * _E2 * r) / (1 + Q) +
+          np.sqrt(0.5 * _A * _A * (1 + 1 / Q)
+                  - (P * (1 - _E2) * ez * ez) / (Q * (1 + Q))
+                  - 0.5 * P * r * r))
+    U = np.sqrt((r - _E2 * r0) ** 2 + ez * ez)
+    V = np.sqrt((r - _E2 * r0) ** 2 + (1 - _E2) * ez * ez)
+    Z0 = b * b * ez / (_A * V)
+    lat_out = np.degrees(np.arctan((ez + ep2 * Z0) / r))
+
+    return lat_out, lon_out
+
+
+def transform_geometries_to_enu(geometries, ref_lat, ref_lon):
+    """Convert a list of OGR geometries from WGS84 to ENU meters.
+
+    Each geometry is cloned and its vertices are transformed in-place
+    from (lon, lat) degrees to (east, north) meters.
+
+    Args:
+        geometries: List of OGR Geometry objects in WGS84.
+        ref_lat: Reference latitude in degrees.
+        ref_lon: Reference longitude in degrees.
+
+    Returns:
+        List of new OGR Geometry objects with coordinates in ENU meters.
+    """
+    result = []
+    for geom in geometries:
+        result.append(_transform_geometry(geom, ref_lat, ref_lon))
+    return result
+
+
+def _transform_geometry(geom, ref_lat, ref_lon):
+    """Recursively transform an OGR geometry to ENU meters."""
+    geom_type = geom.GetGeometryType() & 0xFF
+
+    if geom_type in (1,):  # Point
+        lon, lat = geom.GetX(), geom.GetY()
+        east, north = latlon_to_enu(lat, lon, ref_lat, ref_lon)
+        pt = ogr.Geometry(ogr.wkbPoint)
+        pt.AddPoint(east, north)
+        return pt
+
+    if geom_type in (2,):  # LineString
+        line = ogr.Geometry(ogr.wkbLineString)
+        for i in range(geom.GetPointCount()):
+            lon, lat = geom.GetX(i), geom.GetY(i)
+            east, north = latlon_to_enu(lat, lon, ref_lat, ref_lon)
+            line.AddPoint(east, north)
+        return line
+
+    if geom_type in (3,):  # Polygon
+        poly = ogr.Geometry(ogr.wkbPolygon)
+        for ring_idx in range(geom.GetGeometryCount()):
+            ring_in = geom.GetGeometryRef(ring_idx)
+            ring_out = ogr.Geometry(ogr.wkbLinearRing)
+            for i in range(ring_in.GetPointCount()):
+                lon, lat = ring_in.GetX(i), ring_in.GetY(i)
+                east, north = latlon_to_enu(lat, lon, ref_lat, ref_lon)
+                ring_out.AddPoint(east, north)
+            poly.AddGeometry(ring_out)
+        return poly
+
+    # Multi/collection types: recurse
+    if geom_type in (4, 5, 6, 7):
+        multi = ogr.Geometry(geom.GetGeometryType())
+        for i in range(geom.GetGeometryCount()):
+            multi.AddGeometry(
+                _transform_geometry(geom.GetGeometryRef(i), ref_lat, ref_lon)
+            )
+        return multi
+
+    # Fallback: clone as-is
+    return geom.Clone()

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/feature_models.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/feature_models.py
@@ -17,7 +17,7 @@
 import math
 import re
 
-from marine_autonomy.wgs84 import toECEFfromDegrees
+from .coordinates import latlon_to_enu
 
 # Default extrusion heights by OBJL code
 _BUILDING_HEIGHTS = {
@@ -129,31 +129,22 @@ def _sanitize_objnam(objnam: str) -> str:
 
 
 def _latlon_to_enu(lat, lon, ref_lat, ref_lon):
-    """Convert WGS84 lat/lon to local ENU meters via ECEF."""
-    rx, ry, rz = toECEFfromDegrees(ref_lat, ref_lon)
-    px, py, pz = toECEFfromDegrees(lat, lon)
-    dx, dy, dz = px - rx, py - ry, pz - rz
-    lat_r = math.radians(ref_lat)
-    lon_r = math.radians(ref_lon)
-    sin_lat = math.sin(lat_r)
-    cos_lat = math.cos(lat_r)
-    sin_lon = math.sin(lon_r)
-    cos_lon = math.cos(lon_r)
-    east = -sin_lon * dx + cos_lon * dy
-    north = (-sin_lat * cos_lon * dx
-             - sin_lat * sin_lon * dy
-             + cos_lat * dz)
-    return east, north
+    """Convert WGS84 lat/lon to local ENU meters via ECEF.
+
+    Thin wrapper around coordinates.latlon_to_enu for backward compatibility.
+    """
+    return latlon_to_enu(lat, lon, ref_lat, ref_lon)
 
 
-def _sample_terrain_elevation(lat, lon, terrain, bbox):
-    """Look up terrain elevation at a lat/lon via bilinear interpolation.
+def _sample_terrain_elevation(east, north, terrain, terrain_bounds):
+    """Look up terrain elevation at an ENU position via bilinear interpolation.
 
     Args:
-        lat: Latitude in degrees.
-        lon: Longitude in degrees.
+        east: Easting in meters (ENU).
+        north: Northing in meters (ENU).
         terrain: 2D numpy array, north-up (row 0 = north).
-        bbox: BoundingBox with south/north/west/east.
+        terrain_bounds: dict with 'min_east', 'max_east', 'min_north',
+            'max_north' defining the ENU extent of the terrain grid.
 
     Returns:
         Elevation in meters, or 0.0 if outside bounds.
@@ -161,10 +152,15 @@ def _sample_terrain_elevation(lat, lon, terrain, bbox):
     if terrain is None:
         return 0.0
     rows, cols = terrain.shape
+    min_east = terrain_bounds['min_east']
+    max_east = terrain_bounds['max_east']
+    min_north = terrain_bounds['min_north']
+    max_north = terrain_bounds['max_north']
+
     # Fractional column (west=0, east=cols-1)
-    fc = (lon - bbox.west) / (bbox.east - bbox.west) * (cols - 1)
+    fc = (east - min_east) / (max_east - min_east) * (cols - 1)
     # Fractional row (north=0, south=rows-1)
-    fr = (bbox.north - lat) / (bbox.north - bbox.south) * (rows - 1)
+    fr = (max_north - north) / (max_north - min_north) * (rows - 1)
 
     if fc < 0 or fc > cols - 1 or fr < 0 or fr > rows - 1:
         return 0.0
@@ -860,7 +856,7 @@ def _pylon_model(name, x, y, z, height, collision=True):
 
 def generate_feature_models(
     features, center_lat, center_lon,
-    terrain=None, bbox=None, debug=False,
+    terrain=None, terrain_bounds=None, debug=False,
     skip_categories=None, simplify_tolerance=0.0,
     max_wall_segments=None,
 ):
@@ -871,7 +867,9 @@ def generate_feature_models(
         center_lat: World center latitude (WGS84 degrees).
         center_lon: World center longitude (WGS84 degrees).
         terrain: Optional 2D numpy array of elevation (north-up, meters).
-        bbox: Optional BoundingBox for terrain sampling.
+        terrain_bounds: Optional dict with 'min_east', 'max_east',
+            'min_north', 'max_north' defining the ENU extent of the
+            terrain grid (meters).
         debug: If True, polygon features use thin (0.2m) extrusions with
             distinct colors per type for footprint visualization.
         skip_categories: Optional set of category names to skip (e.g.
@@ -896,9 +894,10 @@ def generate_feature_models(
         features.buildings if 'buildings' not in skip else []
     ):
         centroid = building.geometry.Centroid()
-        z = _sample_terrain_elevation(
-            centroid.GetY(), centroid.GetX(), terrain, bbox
+        cx, cy = _latlon_to_enu(
+            centroid.GetY(), centroid.GetX(), center_lat, center_lon
         )
+        z = _sample_terrain_elevation(cx, cy, terrain, terrain_bounds)
         if debug:
             height = 0.2
             amb, dif = _DEBUG_COLORS['building']
@@ -1006,9 +1005,7 @@ def generate_feature_models(
         x, y = _latlon_to_enu(
             beacon.lat, beacon.lon, center_lat, center_lon
         )
-        z = _sample_terrain_elevation(
-            beacon.lat, beacon.lon, terrain, bbox
-        )
+        z = _sample_terrain_elevation(x, y, terrain, terrain_bounds)
         models.append(_beacon_model(
             f'beacon_{i:04d}', x, y, z=z, colour_code=beacon.colour,
             collision=_LAND,
@@ -1021,9 +1018,7 @@ def generate_feature_models(
         x, y = _latlon_to_enu(
             light.lat, light.lon, center_lat, center_lon
         )
-        z = _sample_terrain_elevation(
-            light.lat, light.lon, terrain, bbox
-        )
+        z = _sample_terrain_elevation(x, y, terrain, terrain_bounds)
         models.append(_light_model(f'light_{i:04d}', x, y, z=z,
                                    tower_height=light.height,
                                    colour_code=light.colour,
@@ -1085,7 +1080,7 @@ def generate_feature_models(
         else []
     ):
         x, y = _latlon_to_enu(mf.lat, mf.lon, center_lat, center_lon)
-        z = _sample_terrain_elevation(mf.lat, mf.lon, terrain, bbox)
+        z = _sample_terrain_elevation(x, y, terrain, terrain_bounds)
         models.append(_morfac_model(f'morfac_{i:04d}', x, y, z, mf.catmor,
                                     collision=_LAND))
 
@@ -1096,7 +1091,7 @@ def generate_feature_models(
         x, y = _latlon_to_enu(
             crane.lat, crane.lon, center_lat, center_lon
         )
-        z = _sample_terrain_elevation(crane.lat, crane.lon, terrain, bbox)
+        z = _sample_terrain_elevation(x, y, terrain, terrain_bounds)
         models.append(_crane_model(
             f'crane_{i:04d}', x, y, z, crane.catcrn, crane.height,
             collision=_LAND,
@@ -1109,7 +1104,7 @@ def generate_feature_models(
         x, y = _latlon_to_enu(
             pylon.lat, pylon.lon, center_lat, center_lon
         )
-        z = _sample_terrain_elevation(pylon.lat, pylon.lon, terrain, bbox)
+        z = _sample_terrain_elevation(x, y, terrain, terrain_bounds)
         models.append(_pylon_model(
             f'pylon_{i:04d}', x, y, z, pylon.height,
             collision=_LAND,

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/generate_world.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/generate_world.py
@@ -15,13 +15,13 @@
 """CLI entry point for S57 world generation."""
 
 import argparse
-import math
 import os
 import sys
 import textwrap
 from datetime import datetime
 
 from .bathy_fetcher import fetch_etopo
+from .coordinates import latlon_to_enu
 from .feature_models import generate_feature_models
 from .heightmap import terrain_to_heightmap
 from .osm_fetcher import fetch_osm_features
@@ -29,13 +29,6 @@ from .osm_matcher import match_and_enrich
 from .s57_reader import BoundingBox, read_enc_directory
 from .terrain import build_terrain
 from .world_builder import generate_world_sdf
-
-# WGS84 approximate meters per degree
-_METERS_PER_DEG_LAT = 111_320.0
-
-
-def _meters_per_deg_lon(lat_deg):
-    return _METERS_PER_DEG_LAT * math.cos(math.radians(lat_deg))
 
 
 def _parse_bbox(s):
@@ -60,18 +53,21 @@ def _parse_tile(s):
 
 def _bbox_center_enu(tile_bbox, world_center_lat, world_center_lon):
     """Compute ENU offset of a tile's center from the world center."""
-    tile_clat = tile_bbox.center_lat
-    tile_clon = tile_bbox.center_lon
-    enu_x = (tile_clon - world_center_lon) * _meters_per_deg_lon(world_center_lat)
-    enu_y = (tile_clat - world_center_lat) * _METERS_PER_DEG_LAT
-    return enu_x, enu_y
+    return latlon_to_enu(
+        tile_bbox.center_lat, tile_bbox.center_lon,
+        world_center_lat, world_center_lon,
+    )
 
 
 def _bbox_size_meters(bbox):
-    """Compute approximate size of a bbox in meters."""
-    size_y = (bbox.north - bbox.south) * _METERS_PER_DEG_LAT
-    size_x = (bbox.east - bbox.west) * _meters_per_deg_lon(bbox.center_lat)
-    return size_x, size_y
+    """Compute size of a bbox in meters using ECEF-based ENU."""
+    e_sw, n_sw = latlon_to_enu(
+        bbox.south, bbox.west, bbox.center_lat, bbox.center_lon,
+    )
+    e_ne, n_ne = latlon_to_enu(
+        bbox.north, bbox.east, bbox.center_lat, bbox.center_lon,
+    )
+    return e_ne - e_sw, n_ne - n_sw
 
 
 def parse_args(argv=None):
@@ -196,7 +192,8 @@ def parse_args(argv=None):
     return parser.parse_args(argv)
 
 
-def _build_single_tile(args, bbox, grid_size, s57_features, model_name="terrain"):
+def _build_single_tile(args, bbox, grid_size, s57_features,
+                       ref_lat, ref_lon, model_name="terrain"):
     """Build terrain and heightmap for a single tile.
 
     Returns (terrain_array, terrain_info, heightmap_info).
@@ -215,6 +212,8 @@ def _build_single_tile(args, bbox, grid_size, s57_features, model_name="terrain"
     print(f"  Building terrain ({grid_size}x{grid_size})...")
     terrain, terrain_info = build_terrain(
         bbox=bbox,
+        ref_lat=ref_lat,
+        ref_lon=ref_lon,
         base_elevation=elevation,
         base_geotransform=metadata["geotransform"] if metadata else None,
         s57_features=s57_features,
@@ -325,6 +324,8 @@ def main(argv=None):
         print(f"  Added {n_added} OSM-only buildings")
 
     # Step 2-4: Build terrain tiles
+    ref_lat = bbox.center_lat
+    ref_lon = bbox.center_lon
     multi_tile = len(tiles) > 1
     first_terrain = None
     first_terrain_info = None
@@ -337,12 +338,13 @@ def main(argv=None):
             print(f"\nTile '{name}' ({grid_size}x{grid_size}):")
             terrain, terrain_info, heightmap_info = _build_single_tile(
                 args, tile_bbox, grid_size, s57_features,
+                ref_lat=ref_lat, ref_lon=ref_lon,
                 model_name=f"terrain_{name}",
             )
             # Embed ENU offset directly in the heightmap <pos> element
             # (Gazebo's OGRE2 heightmap renderer uses <pos>, not model pose)
             enu_x, enu_y = _bbox_center_enu(
-                tile_bbox, bbox.center_lat, bbox.center_lon,
+                tile_bbox, ref_lat, ref_lon,
             )
             heightmap_info["pos_x"] = enu_x
             heightmap_info["pos_y"] = enu_y
@@ -363,6 +365,7 @@ def main(argv=None):
             print("Using S57-only terrain (land ramp + soundings).")
         first_terrain, first_terrain_info, heightmap_info = _build_single_tile(
             args, tile_bbox, grid_size, s57_features,
+            ref_lat=ref_lat, ref_lon=ref_lon,
             model_name=f"{args.world_name}_terrain",
         )
         heightmap_result = heightmap_info
@@ -381,11 +384,24 @@ def main(argv=None):
         min_span = min(bbox.north - bbox.south, bbox.east - bbox.west)
         simplify_tol = min_span / 10000.0  # ~1m for typical coastal regions
 
+    # Compute terrain bounds in ENU for feature elevation sampling
+    terrain_bounds = None
+    if first_terrain is not None:
+        e_sw, n_sw = latlon_to_enu(bbox.south, bbox.west, ref_lat, ref_lon)
+        e_ne, n_ne = latlon_to_enu(bbox.north, bbox.east, ref_lat, ref_lon)
+        terrain_bounds = {
+            'min_east': e_sw,
+            'max_east': e_ne,
+            'min_north': n_sw,
+            'max_north': n_ne,
+        }
+
     if not args.no_features and s57_features is not None:
         print("Generating S57 feature models...")
         feature_sdf = generate_feature_models(
-            s57_features, bbox.center_lat, bbox.center_lon,
-            terrain=first_terrain, bbox=bbox, debug=args.debug_features,
+            s57_features, ref_lat, ref_lon,
+            terrain=first_terrain, terrain_bounds=terrain_bounds,
+            debug=args.debug_features,
             skip_categories=skip_categories,
             simplify_tolerance=simplify_tol,
             max_wall_segments=args.max_wall_segments,

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/terrain.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/terrain.py
@@ -22,25 +22,25 @@ from osgeo import gdal, ogr, osr
 from scipy.interpolate import LinearNDInterpolator
 from scipy.ndimage import distance_transform_edt
 
+from .coordinates import (
+    enu_to_latlon_array,
+    latlon_to_enu,
+    latlon_to_enu_array,
+    transform_geometries_to_enu,
+)
 from .s57_reader import BoundingBox, DepthArea, S57Features
 
 logger = logging.getLogger(__name__)
-
-# WGS84 meters per degree (approximate, varies with latitude)
-_METERS_PER_DEG_LAT = 111_320.0
 
 # Shoreline ramp parameters
 _RAMP_DISTANCE_M = 25.0  # distance over which land ramps up
 _RAMP_MAX_ELEVATION = 5.0  # maximum land elevation in meters
 
 
-def _meters_per_deg_lon(lat_deg: float) -> float:
-    """Approximate meters per degree of longitude at a given latitude."""
-    return _METERS_PER_DEG_LAT * np.cos(np.radians(lat_deg))
-
-
 def build_terrain(
     bbox: BoundingBox,
+    ref_lat: float,
+    ref_lon: float,
     base_elevation: Optional[np.ndarray] = None,
     base_geotransform: Optional[tuple] = None,
     s57_features: Optional[S57Features] = None,
@@ -48,13 +48,14 @@ def build_terrain(
 ) -> Tuple[np.ndarray, dict]:
     """Build a terrain grid by combining base elevation with S57 data.
 
-    The output grid is in a local ENU frame centered on the bbox center.
-    If base_elevation is None, terrain is built from S57 land areas and
-    soundings: land cells get a synthetic ramp from the shoreline, water
-    cells get interpolated sounding depths.
+    The output grid is in a local ENU frame centered on (ref_lat, ref_lon).
+    Grid coordinates are built in ENU meters using ECEF-based transforms,
+    ensuring alignment with 3D feature placement.
 
     Args:
         bbox: Geographic bounding box.
+        ref_lat: Reference latitude for ENU origin (degrees).
+        ref_lon: Reference longitude for ENU origin (degrees).
         base_elevation: Optional 2D array of elevation from ETOPO/GEBCO
             (meters, positive up). If None, uses S57-only terrain with
             shoreline ramp.
@@ -70,33 +71,37 @@ def build_terrain(
         terrain_info: dict with 'size_x', 'size_y', 'min_elevation',
             'max_elevation', 'center_lat', 'center_lon'.
     """
-    center_lat = bbox.center_lat
-    center_lon = bbox.center_lon
-    m_per_deg_lon = _meters_per_deg_lon(center_lat)
+    # Compute ENU corners for the bounding box
+    e_sw, n_sw = latlon_to_enu(bbox.south, bbox.west, ref_lat, ref_lon)
+    e_ne, n_ne = latlon_to_enu(bbox.north, bbox.east, ref_lat, ref_lon)
 
-    # Compute physical extent in meters
-    size_x = (bbox.east - bbox.west) * m_per_deg_lon
-    size_y = (bbox.north - bbox.south) * _METERS_PER_DEG_LAT
+    size_x = e_ne - e_sw
+    size_y = n_ne - n_sw
 
-    # Build output grid coordinates in degrees
-    lons = np.linspace(bbox.west, bbox.east, grid_size)
-    lats = np.linspace(bbox.north, bbox.south, grid_size)  # north-up
-    grid_lons, grid_lats = np.meshgrid(lons, lats)
+    # Build output grid in ENU meters (north-up: row 0 = north)
+    east_1d = np.linspace(e_sw, e_ne, grid_size)
+    north_1d = np.linspace(n_ne, n_sw, grid_size)  # north-up
+    grid_east, grid_north = np.meshgrid(east_1d, north_1d)
 
     if base_elevation is not None and base_geotransform is not None:
-        # Sample base elevation onto output grid using bilinear interpolation
+        # Convert ENU grid points back to lat/lon for ETOPO sampling
+        grid_lats, grid_lons = enu_to_latlon_array(
+            grid_east, grid_north, ref_lat, ref_lon,
+        )
         terrain = _sample_raster(
             base_elevation, base_geotransform, grid_lons, grid_lats
         )
         # Overlay S57 soundings if available
         if s57_features is not None and s57_features.soundings:
             terrain = _overlay_soundings(
-                terrain, grid_lons, grid_lats, s57_features, bbox
+                terrain, grid_east, grid_north,
+                s57_features, ref_lat, ref_lon,
             )
     else:
         # S57-only terrain: land ramp + sounding interpolation
         terrain = _build_s57_terrain(
-            grid_lons, grid_lats, s57_features, grid_size, bbox
+            grid_east, grid_north, s57_features, grid_size,
+            size_x, size_y, ref_lat, ref_lon,
         )
 
     terrain_info = {
@@ -104,8 +109,8 @@ def build_terrain(
         "size_y": size_y,
         "min_elevation": float(np.nanmin(terrain)),
         "max_elevation": float(np.nanmax(terrain)),
-        "center_lat": center_lat,
-        "center_lon": center_lon,
+        "center_lat": ref_lat,
+        "center_lon": ref_lon,
         "grid_size": grid_size,
     }
 
@@ -113,11 +118,14 @@ def build_terrain(
 
 
 def _build_s57_terrain(
-    grid_lons: np.ndarray,
-    grid_lats: np.ndarray,
+    grid_east: np.ndarray,
+    grid_north: np.ndarray,
     s57_features: Optional[S57Features],
     grid_size: int,
-    bbox: BoundingBox,
+    size_x: float,
+    size_y: float,
+    ref_lat: float,
+    ref_lon: float,
 ) -> np.ndarray:
     """Build terrain from S57 land areas and soundings.
 
@@ -128,28 +136,29 @@ def _build_s57_terrain(
     if s57_features is None:
         return np.zeros((grid_size, grid_size), dtype=np.float64)
 
+    # ENU grid extents
+    min_east = grid_east[0, 0]
+    max_east = grid_east[0, -1]
+    max_north = grid_north[0, 0]
+    min_north = grid_north[-1, 0]
+
     # Rasterize land areas and coastlines onto a binary mask
     land_mask = _rasterize_land(
         s57_features.land_areas, s57_features.coastlines,
-        bbox, grid_size,
+        grid_size, min_east, max_east, min_north, max_north,
+        ref_lat, ref_lon,
     )
 
-    # Compute distance from shore for land cells
-    center_lat = bbox.center_lat
-    m_per_deg_lon = _meters_per_deg_lon(center_lat)
+    # Cell sizes in meters (exact from ENU grid)
+    cell_size_x = size_x / (grid_size - 1)
+    cell_size_y = size_y / (grid_size - 1)
 
-    # Cell sizes in meters (anisotropic)
-    cell_size_y = (bbox.north - bbox.south) / (grid_size - 1) * _METERS_PER_DEG_LAT
-    cell_size_x = (bbox.east - bbox.west) / (grid_size - 1) * m_per_deg_lon
-
-    # Distance transform on inverted mask (distance from water/shore into land)
-    # Invert: water=1 (background), land=0 (features we measure distance from edge of)
-    water_mask = ~land_mask
+    # Distance transform on land mask (distance from water/shore into land)
     distance_cells = distance_transform_edt(
         land_mask, sampling=[cell_size_y, cell_size_x]
     )
 
-    # Ramp land elevation: linear 0→5m over 25m, capped at 5m
+    # Ramp land elevation: linear 0->5m over 25m, capped at 5m
     land_elevation = np.minimum(
         distance_cells / _RAMP_DISTANCE_M * _RAMP_MAX_ELEVATION,
         _RAMP_MAX_ELEVATION,
@@ -157,13 +166,15 @@ def _build_s57_terrain(
 
     # Start with water depths from soundings
     water_terrain = _synthesize_from_s57(
-        grid_lons, grid_lats, s57_features, grid_size
+        grid_east, grid_north, s57_features, grid_size, ref_lat, ref_lon,
     )
 
     # Clamp interpolated depths to depth area ranges
     if s57_features.depth_areas:
         da_min, da_max = _rasterize_depth_areas(
-            s57_features.depth_areas, bbox, grid_size,
+            s57_features.depth_areas, grid_size,
+            min_east, max_east, min_north, max_north,
+            ref_lat, ref_lon,
         )
         da_mask = ~np.isnan(da_min)
         if np.any(da_mask):
@@ -180,67 +191,69 @@ def _build_s57_terrain(
 
 
 def _rasterize_land(
-    land_areas, coastlines, bbox: BoundingBox, grid_size: int,
+    land_areas, coastlines, grid_size: int,
+    min_east: float, max_east: float,
+    min_north: float, max_north: float,
+    ref_lat: float, ref_lon: float,
 ) -> np.ndarray:
     """Rasterize LNDARE polygons and COALNE lines onto a binary grid.
+
+    Geometries are transformed from WGS84 to ENU before rasterization.
 
     Returns a boolean mask where True = land.
     """
     if not land_areas and not coastlines:
         return np.zeros((grid_size, grid_size), dtype=bool)
 
-    # Create in-memory OGR dataset with all land geometries
+    # GeoTransform in ENU meters (no CRS needed)
+    pixel_width = (max_east - min_east) / grid_size
+    pixel_height = (max_north - min_north) / grid_size
+    gt = (min_east, pixel_width, 0.0, max_north, 0.0, -pixel_height)
+
+    # Transform and rasterize land area polygons
     mem_driver = ogr.GetDriverByName('Memory')
     mem_ds = mem_driver.CreateDataSource('land')
-    srs = osr.SpatialReference()
-    srs.ImportFromEPSG(4326)
-    mem_layer = mem_ds.CreateLayer('land', srs, ogr.wkbPolygon)
+    mem_layer = mem_ds.CreateLayer('land', None, ogr.wkbPolygon)
 
-    # Add land area polygons
-    for geom in land_areas:
-        feat = ogr.Feature(mem_layer.GetLayerDefn())
-        feat.SetGeometry(geom)
-        mem_layer.CreateFeature(feat)
+    if land_areas:
+        enu_land = transform_geometries_to_enu(
+            land_areas, ref_lat, ref_lon,
+        )
+        for geom in enu_land:
+            feat = ogr.Feature(mem_layer.GetLayerDefn())
+            feat.SetGeometry(geom)
+            mem_layer.CreateFeature(feat)
 
-    # Rasterize using GDAL
-    # GeoTransform: (west, pixel_width, 0, north, 0, -pixel_height)
-    pixel_width = (bbox.east - bbox.west) / grid_size
-    pixel_height = (bbox.north - bbox.south) / grid_size
-    gt = (bbox.west, pixel_width, 0.0, bbox.north, 0.0, -pixel_height)
-
-    # Create in-memory raster
     rast_driver = gdal.GetDriverByName('MEM')
     rast_ds = rast_driver.Create('', grid_size, grid_size, 1, gdal.GDT_Byte)
     rast_ds.SetGeoTransform(gt)
-    rast_ds.SetProjection(srs.ExportToWkt())
     band = rast_ds.GetRasterBand(1)
     band.Fill(0)
 
-    # Rasterize polygons — burn value 1 for land
     gdal.RasterizeLayer(rast_ds, [1], mem_layer, burn_values=[1])
-
-    # Read result
     land_mask = band.ReadAsArray().astype(bool)
 
     # Also rasterize coastlines as land boundary pixels
     if coastlines:
-        line_layer = mem_ds.CreateLayer('coast', srs, ogr.wkbLineString)
-        for geom in coastlines:
+        enu_coastlines = transform_geometries_to_enu(
+            coastlines, ref_lat, ref_lon,
+        )
+        line_layer = mem_ds.CreateLayer('coast', None, ogr.wkbLineString)
+        for geom in enu_coastlines:
             feat = ogr.Feature(line_layer.GetLayerDefn())
             feat.SetGeometry(geom)
             line_layer.CreateFeature(feat)
 
-        # Burn coastline pixels onto the same mask
-        coast_ds = rast_driver.Create('', grid_size, grid_size, 1, gdal.GDT_Byte)
+        coast_ds = rast_driver.Create(
+            '', grid_size, grid_size, 1, gdal.GDT_Byte,
+        )
         coast_ds.SetGeoTransform(gt)
-        coast_ds.SetProjection(srs.ExportToWkt())
         coast_band = coast_ds.GetRasterBand(1)
         coast_band.Fill(0)
         gdal.RasterizeLayer(coast_ds, [1], line_layer, burn_values=[1])
         coast_mask = coast_band.ReadAsArray().astype(bool)
         land_mask |= coast_mask
 
-    # Clean up
     mem_ds = None
     rast_ds = None
 
@@ -248,7 +261,10 @@ def _rasterize_land(
 
 
 def _rasterize_depth_areas(
-    depth_areas: list, bbox: BoundingBox, grid_size: int,
+    depth_areas: list, grid_size: int,
+    min_east: float, max_east: float,
+    min_north: float, max_north: float,
+    ref_lat: float, ref_lon: float,
 ) -> Tuple[np.ndarray, np.ndarray]:
     """Rasterize depth areas with scale ordering onto min/max depth grids.
 
@@ -270,28 +286,30 @@ def _rasterize_depth_areas(
         depth_areas, key=lambda da: da.compilation_scale, reverse=True,
     )
 
-    # GeoTransform matching _rasterize_land
-    pixel_width = (bbox.east - bbox.west) / grid_size
-    pixel_height = (bbox.north - bbox.south) / grid_size
-    gt = (bbox.west, pixel_width, 0.0, bbox.north, 0.0, -pixel_height)
+    # GeoTransform in ENU meters
+    pixel_width = (max_east - min_east) / grid_size
+    pixel_height = (max_north - min_north) / grid_size
+    gt = (min_east, pixel_width, 0.0, max_north, 0.0, -pixel_height)
 
-    srs = osr.SpatialReference()
-    srs.ImportFromEPSG(4326)
-    wkt = srs.ExportToWkt()
     rast_driver = gdal.GetDriverByName('MEM')
 
     for da in sorted_areas:
-        # Rasterize this polygon to a mask
+        # Transform geometry to ENU
+        enu_geom = transform_geometries_to_enu(
+            [da.geometry], ref_lat, ref_lon,
+        )[0]
+
         mem_driver = ogr.GetDriverByName('Memory')
         mem_ds = mem_driver.CreateDataSource('da')
-        mem_layer = mem_ds.CreateLayer('da', srs, ogr.wkbPolygon)
+        mem_layer = mem_ds.CreateLayer('da', None, ogr.wkbPolygon)
         feat = ogr.Feature(mem_layer.GetLayerDefn())
-        feat.SetGeometry(da.geometry)
+        feat.SetGeometry(enu_geom)
         mem_layer.CreateFeature(feat)
 
-        rast_ds = rast_driver.Create('', grid_size, grid_size, 1, gdal.GDT_Byte)
+        rast_ds = rast_driver.Create(
+            '', grid_size, grid_size, 1, gdal.GDT_Byte,
+        )
         rast_ds.SetGeoTransform(gt)
-        rast_ds.SetProjection(wkt)
         band = rast_ds.GetRasterBand(1)
         band.Fill(0)
         gdal.RasterizeLayer(rast_ds, [1], mem_layer, burn_values=[1])
@@ -307,41 +325,46 @@ def _rasterize_depth_areas(
 
 
 def _synthesize_from_s57(
-    grid_lons: np.ndarray,
-    grid_lats: np.ndarray,
+    grid_east: np.ndarray,
+    grid_north: np.ndarray,
     s57_features: Optional[S57Features],
     grid_size: int,
+    ref_lat: float,
+    ref_lon: float,
 ) -> np.ndarray:
     """Synthesize terrain from S57 sounding and depth area data.
 
     When no base raster is available, we interpolate a surface directly
-    from S57 soundings. If no soundings exist either, returns a flat
-    surface at 0m elevation.
+    from S57 soundings in ENU space. If no soundings exist either,
+    returns a flat surface at 0m elevation.
     """
     if s57_features is None or not s57_features.soundings:
         return np.zeros((grid_size, grid_size), dtype=np.float64)
 
-    # Build interpolation from all soundings
-    snd_lons = np.array([s.lon for s in s57_features.soundings])
+    # Convert soundings to ENU
     snd_lats = np.array([s.lat for s in s57_features.soundings])
+    snd_lons = np.array([s.lon for s in s57_features.soundings])
     snd_elevations = np.array([-s.depth for s in s57_features.soundings])
+    snd_east, snd_north = latlon_to_enu_array(
+        snd_lats, snd_lons, ref_lat, ref_lon,
+    )
 
     try:
         interp = LinearNDInterpolator(
-            np.column_stack([snd_lons, snd_lats]),
+            np.column_stack([snd_east, snd_north]),
             snd_elevations,
         )
-        terrain = interp(grid_lons, grid_lats)
+        terrain = interp(grid_east, grid_north)
         # Fill NaN (outside convex hull of soundings) with nearest value
         from scipy.interpolate import NearestNDInterpolator
         nan_mask = np.isnan(terrain)
         if np.any(nan_mask):
             nearest = NearestNDInterpolator(
-                np.column_stack([snd_lons, snd_lats]),
+                np.column_stack([snd_east, snd_north]),
                 snd_elevations,
             )
             terrain[nan_mask] = nearest(
-                grid_lons[nan_mask], grid_lats[nan_mask]
+                grid_east[nan_mask], grid_north[nan_mask]
             )
         return terrain
     except Exception:
@@ -361,8 +384,6 @@ def _sample_raster(
     """Bilinear interpolation of raster data at query lat/lon points."""
     gt = geotransform
     # Convert geographic coords to pixel coords
-    # pixel_x = (lon - gt[0]) / gt[1]
-    # pixel_y = (lat - gt[3]) / gt[5]
     pixel_x = (query_lons - gt[0]) / gt[1]
     pixel_y = (query_lats - gt[3]) / gt[5]
 
@@ -392,10 +413,11 @@ def _sample_raster(
 
 def _overlay_soundings(
     terrain: np.ndarray,
-    grid_lons: np.ndarray,
-    grid_lats: np.ndarray,
+    grid_east: np.ndarray,
+    grid_north: np.ndarray,
     s57_features: S57Features,
-    bbox: BoundingBox,
+    ref_lat: float,
+    ref_lon: float,
 ) -> np.ndarray:
     """Refine terrain using S57 sounding data.
 
@@ -406,25 +428,27 @@ def _overlay_soundings(
     if not s57_features.soundings:
         return terrain
 
-    # Collect sounding points
-    snd_lons = np.array([s.lon for s in s57_features.soundings])
+    # Convert soundings to ENU
     snd_lats = np.array([s.lat for s in s57_features.soundings])
-    # S57 depths are positive down; convert to elevation (positive up)
+    snd_lons = np.array([s.lon for s in s57_features.soundings])
     snd_elevations = np.array([-s.depth for s in s57_features.soundings])
+    snd_east, snd_north = latlon_to_enu_array(
+        snd_lats, snd_lons, ref_lat, ref_lon,
+    )
 
     # Sample base elevation at sounding locations
-    # (we'd need the base raster for this, but we can approximate by
-    # interpolating the already-sampled terrain grid)
     from scipy.interpolate import RegularGridInterpolator
 
-    lats_1d = grid_lats[:, 0]  # north to south
-    lons_1d = grid_lons[0, :]  # west to east
+    north_1d = grid_north[:, 0]  # north to south
+    east_1d = grid_east[0, :]    # west to east
 
     base_interp = RegularGridInterpolator(
-        (lats_1d, lons_1d), terrain,
+        (north_1d, east_1d), terrain,
         method="linear", bounds_error=False, fill_value=None
     )
-    base_at_soundings = base_interp(np.column_stack([snd_lats, snd_lons]))
+    base_at_soundings = base_interp(
+        np.column_stack([snd_north, snd_east])
+    )
 
     # Compute corrections (sounding truth minus base estimate)
     corrections = snd_elevations - base_at_soundings
@@ -434,17 +458,17 @@ def _overlay_soundings(
     if not np.any(significant):
         return terrain
 
-    sig_lons = snd_lons[significant]
-    sig_lats = snd_lats[significant]
+    sig_east = snd_east[significant]
+    sig_north = snd_north[significant]
     sig_corrections = corrections[significant]
 
     # Interpolate corrections onto the grid
     try:
         correction_interp = LinearNDInterpolator(
-            np.column_stack([sig_lons, sig_lats]),
+            np.column_stack([sig_east, sig_north]),
             sig_corrections,
         )
-        correction_grid = correction_interp(grid_lons, grid_lats)
+        correction_grid = correction_interp(grid_east, grid_north)
         # Only apply where interpolation succeeded (not NaN)
         valid = ~np.isnan(correction_grid)
         terrain[valid] += correction_grid[valid]

--- a/marine_charts_to_gazebo_world/test/test_coordinates.py
+++ b/marine_charts_to_gazebo_world/test/test_coordinates.py
@@ -1,0 +1,153 @@
+# Copyright 2025 Roland Arsenault
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for coordinates module."""
+
+import numpy as np
+import pytest
+from osgeo import ogr
+
+from marine_charts_to_gazebo_world.coordinates import (
+    enu_to_latlon,
+    enu_to_latlon_array,
+    latlon_to_enu,
+    latlon_to_enu_array,
+    transform_geometries_to_enu,
+)
+
+REF_LAT = 43.075
+REF_LON = -70.71
+
+
+class TestLatLonToEnu:
+
+    def test_center_is_origin(self):
+        """Reference point should map to (0, 0)."""
+        x, y = latlon_to_enu(REF_LAT, REF_LON, REF_LAT, REF_LON)
+        assert x == pytest.approx(0.0)
+        assert y == pytest.approx(0.0)
+
+    def test_north_offset(self):
+        """Point north of reference should have positive northing."""
+        x, y = latlon_to_enu(REF_LAT + 0.001, REF_LON, REF_LAT, REF_LON)
+        assert x == pytest.approx(0.0, abs=0.01)
+        assert y > 0
+        assert y == pytest.approx(111.32, abs=1.0)
+
+    def test_east_offset(self):
+        """Point east of reference should have positive easting."""
+        x, y = latlon_to_enu(REF_LAT, REF_LON + 0.001, REF_LAT, REF_LON)
+        assert y == pytest.approx(0.0, abs=0.01)
+        assert x > 0
+
+
+class TestEnuToLatLon:
+
+    def test_origin_roundtrip(self):
+        """ENU origin should map back to reference point."""
+        lat, lon = enu_to_latlon(0.0, 0.0, REF_LAT, REF_LON)
+        assert lat == pytest.approx(REF_LAT, abs=1e-8)
+        assert lon == pytest.approx(REF_LON, abs=1e-8)
+
+    def test_roundtrip_north(self):
+        """Forward then inverse should recover original lat/lon."""
+        orig_lat = REF_LAT + 0.01
+        orig_lon = REF_LON
+        e, n = latlon_to_enu(orig_lat, orig_lon, REF_LAT, REF_LON)
+        lat, lon = enu_to_latlon(e, n, REF_LAT, REF_LON)
+        assert lat == pytest.approx(orig_lat, abs=1e-6)
+        assert lon == pytest.approx(orig_lon, abs=1e-6)
+
+    def test_roundtrip_diagonal(self):
+        """Roundtrip for a point offset in both E and N."""
+        orig_lat = REF_LAT + 0.005
+        orig_lon = REF_LON + 0.005
+        e, n = latlon_to_enu(orig_lat, orig_lon, REF_LAT, REF_LON)
+        lat, lon = enu_to_latlon(e, n, REF_LAT, REF_LON)
+        assert lat == pytest.approx(orig_lat, abs=1e-6)
+        assert lon == pytest.approx(orig_lon, abs=1e-6)
+
+
+class TestArrayVersions:
+
+    def test_array_matches_scalar(self):
+        """Array version should match scalar for multiple points."""
+        lats = np.array([REF_LAT, REF_LAT + 0.01, REF_LAT - 0.005])
+        lons = np.array([REF_LON, REF_LON + 0.01, REF_LON - 0.005])
+
+        for i in range(len(lats)):
+            e_scalar, n_scalar = latlon_to_enu(
+                lats[i], lons[i], REF_LAT, REF_LON,
+            )
+            e_array, n_array = latlon_to_enu_array(
+                lats, lons, REF_LAT, REF_LON,
+            )
+            assert e_array[i] == pytest.approx(e_scalar, abs=0.01)
+            assert n_array[i] == pytest.approx(n_scalar, abs=0.01)
+
+    def test_inverse_array_roundtrip(self):
+        """enu_to_latlon_array should roundtrip with latlon_to_enu_array."""
+        lats = np.array([REF_LAT + 0.01, REF_LAT - 0.01])
+        lons = np.array([REF_LON + 0.01, REF_LON - 0.01])
+        east, north = latlon_to_enu_array(lats, lons, REF_LAT, REF_LON)
+        lats_out, lons_out = enu_to_latlon_array(
+            east, north, REF_LAT, REF_LON,
+        )
+        np.testing.assert_allclose(lats_out, lats, atol=1e-6)
+        np.testing.assert_allclose(lons_out, lons, atol=1e-6)
+
+
+class TestTransformGeometries:
+
+    def test_polygon_transform(self):
+        """Polygon vertices should be in ENU meters after transform."""
+        ring = ogr.Geometry(ogr.wkbLinearRing)
+        ring.AddPoint(REF_LON, REF_LAT)
+        ring.AddPoint(REF_LON + 0.001, REF_LAT)
+        ring.AddPoint(REF_LON + 0.001, REF_LAT + 0.001)
+        ring.AddPoint(REF_LON, REF_LAT + 0.001)
+        ring.AddPoint(REF_LON, REF_LAT)
+        poly = ogr.Geometry(ogr.wkbPolygon)
+        poly.AddGeometry(ring)
+
+        result = transform_geometries_to_enu([poly], REF_LAT, REF_LON)
+        assert len(result) == 1
+        out_ring = result[0].GetGeometryRef(0)
+        # First vertex should be near origin
+        assert out_ring.GetX(0) == pytest.approx(0.0, abs=0.1)
+        assert out_ring.GetY(0) == pytest.approx(0.0, abs=0.1)
+        # Other vertices should be in meters (order of 80-111m for 0.001 deg)
+        assert 50 < out_ring.GetX(1) < 150
+        assert 50 < out_ring.GetY(2) < 150
+
+    def test_linestring_transform(self):
+        """LineString should transform correctly."""
+        line = ogr.Geometry(ogr.wkbLineString)
+        line.AddPoint(REF_LON, REF_LAT)
+        line.AddPoint(REF_LON + 0.001, REF_LAT)
+
+        result = transform_geometries_to_enu([line], REF_LAT, REF_LON)
+        assert len(result) == 1
+        assert result[0].GetPointCount() == 2
+        assert result[0].GetX(0) == pytest.approx(0.0, abs=0.1)
+
+    def test_point_transform(self):
+        """Point should transform correctly."""
+        pt = ogr.Geometry(ogr.wkbPoint)
+        pt.AddPoint(REF_LON, REF_LAT)
+
+        result = transform_geometries_to_enu([pt], REF_LAT, REF_LON)
+        assert len(result) == 1
+        assert result[0].GetX() == pytest.approx(0.0, abs=0.1)
+        assert result[0].GetY() == pytest.approx(0.0, abs=0.1)

--- a/marine_charts_to_gazebo_world/test/test_feature_models.py
+++ b/marine_charts_to_gazebo_world/test/test_feature_models.py
@@ -19,8 +19,8 @@ import xml.etree.ElementTree as ET
 import pytest
 from osgeo import ogr
 
+from marine_charts_to_gazebo_world.coordinates import latlon_to_enu
 from marine_charts_to_gazebo_world.feature_models import (
-    _latlon_to_enu,
     _sanitize_objnam,
     generate_feature_models,
 )
@@ -53,13 +53,13 @@ class TestLatLonToEnu:
 
     def test_center_is_origin(self):
         """World center should map to (0, 0)."""
-        x, y = _latlon_to_enu(CENTER_LAT, CENTER_LON, CENTER_LAT, CENTER_LON)
+        x, y = latlon_to_enu(CENTER_LAT, CENTER_LON, CENTER_LAT, CENTER_LON)
         assert x == pytest.approx(0.0)
         assert y == pytest.approx(0.0)
 
     def test_north_offset(self):
         """Point north of center should have positive y offset."""
-        x, y = _latlon_to_enu(
+        x, y = latlon_to_enu(
             CENTER_LAT + 0.001, CENTER_LON, CENTER_LAT, CENTER_LON
         )
         assert x == pytest.approx(0.0, abs=0.01)
@@ -68,7 +68,7 @@ class TestLatLonToEnu:
 
     def test_east_offset(self):
         """Point east of center should have positive x offset."""
-        x, y = _latlon_to_enu(
+        x, y = latlon_to_enu(
             CENTER_LAT, CENTER_LON + 0.001, CENTER_LAT, CENTER_LON
         )
         assert y == pytest.approx(0.0, abs=0.01)

--- a/marine_charts_to_gazebo_world/test/test_terrain.py
+++ b/marine_charts_to_gazebo_world/test/test_terrain.py
@@ -63,6 +63,8 @@ class TestBuildTerrainWithBase:
 
         terrain, info = build_terrain(
             bbox=bbox,
+            ref_lat=bbox.center_lat,
+            ref_lon=bbox.center_lon,
             base_elevation=base,
             base_geotransform=gt,
             grid_size=17,
@@ -77,6 +79,8 @@ class TestBuildTerrainWithBase:
 
         terrain, info = build_terrain(
             bbox=bbox,
+            ref_lat=bbox.center_lat,
+            ref_lon=bbox.center_lon,
             base_elevation=base,
             base_geotransform=gt,
             grid_size=5,
@@ -99,6 +103,8 @@ class TestBuildTerrainWithBase:
 
         terrain, info = build_terrain(
             bbox=bbox,
+            ref_lat=bbox.center_lat,
+            ref_lon=bbox.center_lon,
             base_elevation=base,
             base_geotransform=gt,
             s57_features=features,
@@ -133,7 +139,12 @@ class TestBuildS57Terrain:
     def test_no_features_flat(self):
         """No S57 features should produce a flat surface at 0."""
         bbox = BoundingBox(south=43.0, west=-71.0, north=43.01, east=-70.99)
-        terrain, info = build_terrain(bbox=bbox, grid_size=9)
+        terrain, info = build_terrain(
+            bbox=bbox,
+            ref_lat=bbox.center_lat,
+            ref_lon=bbox.center_lon,
+            grid_size=9,
+        )
         assert terrain.shape == (9, 9)
         assert np.all(terrain == 0.0)
 
@@ -149,7 +160,11 @@ class TestBuildS57Terrain:
         ])
         features = S57Features(land_areas=[land_poly])
         terrain, info = build_terrain(
-            bbox=bbox, s57_features=features, grid_size=33,
+            bbox=bbox,
+            ref_lat=bbox.center_lat,
+            ref_lon=bbox.center_lon,
+            s57_features=features,
+            grid_size=33,
         )
         assert terrain.shape == (33, 33)
         # Land cells should have positive elevation
@@ -169,7 +184,11 @@ class TestBuildS57Terrain:
         ])
         features = S57Features(land_areas=[land_poly])
         terrain, info = build_terrain(
-            bbox=bbox, s57_features=features, grid_size=65,
+            bbox=bbox,
+            ref_lat=bbox.center_lat,
+            ref_lon=bbox.center_lon,
+            s57_features=features,
+            grid_size=65,
         )
         # Interior land cells far from shore should reach 5.0m cap
         assert info["max_elevation"] == pytest.approx(5.0)
@@ -194,7 +213,11 @@ class TestBuildS57Terrain:
             land_areas=[land_poly], soundings=soundings,
         )
         terrain, info = build_terrain(
-            bbox=bbox, s57_features=features, grid_size=33,
+            bbox=bbox,
+            ref_lat=bbox.center_lat,
+            ref_lon=bbox.center_lon,
+            s57_features=features,
+            grid_size=33,
         )
         # Should have both positive (land) and negative (water) elevation
         assert info["max_elevation"] > 0.0
@@ -209,7 +232,11 @@ class TestBuildS57Terrain:
         ])
         features = S57Features(coastlines=[coastline])
         terrain, info = build_terrain(
-            bbox=bbox, s57_features=features, grid_size=33,
+            bbox=bbox,
+            ref_lat=bbox.center_lat,
+            ref_lon=bbox.center_lon,
+            s57_features=features,
+            grid_size=33,
         )
         # Coastline pixels should have non-negative elevation
         assert info["max_elevation"] >= 0.0
@@ -244,10 +271,14 @@ class TestDepthAreaClamping:
             depth_areas=[depth_area], soundings=soundings,
         )
         terrain, info = build_terrain(
-            bbox=bbox, s57_features=features, grid_size=33,
+            bbox=bbox,
+            ref_lat=bbox.center_lat,
+            ref_lon=bbox.center_lon,
+            s57_features=features,
+            grid_size=33,
         )
         # All cells should be clamped to DEPARE range:
-        # depths 3-8m → elevation -8 to -3
+        # depths 3-8m -> elevation -8 to -3
         water_cells = terrain[terrain < 0]
         assert len(water_cells) > 0, "Should have water cells"
         assert np.min(water_cells) >= -8.0 - 0.01
@@ -290,7 +321,11 @@ class TestDepthAreaClamping:
             depth_areas=[coarse_da, detail_da], soundings=soundings,
         )
         terrain, info = build_terrain(
-            bbox=bbox, s57_features=features, grid_size=33,
+            bbox=bbox,
+            ref_lat=bbox.center_lat,
+            ref_lon=bbox.center_lon,
+            s57_features=features,
+            grid_size=33,
         )
         # Center of grid (within detailed chart area) should use 8-12m range
         center = terrain[16, 16]


### PR DESCRIPTION
## Summary

- Extract coordinate transforms to shared `coordinates.py` module using ECEF-based ENU via `marine_autonomy.wgs84`
- Convert terrain pipeline to build grid in ENU meter space instead of lat/lon with cosine approximation
- Update feature elevation sampling to work in ENU space with `terrain_bounds` dict
- Replace cosine-approximation helpers in `generate_world.py` with ECEF-based conversions

This eliminates visible misalignment between terrain textures and 3D feature models that occurs with the cosine approximation over large bounding boxes. Prerequisite for terrain texture feature (#34).

**Depends on**: PR #27 (feature_models.py base)

## Test plan

- [x] All 75 existing tests pass (`colcon test`)
- [x] New `test_coordinates.py` tests: roundtrips, array vs scalar consistency, geometry transform
- [ ] Regenerate Portsmouth harbor world and visually confirm feature alignment in Gazebo
- [ ] Prototype OSM texture rasterization using ENU coordinates

Closes #35

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
