### PR TITLE
feat: group features by source + add unh_pier world

### DIFF
--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/feature_models.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/feature_models.py
@@ -854,13 +854,49 @@ def _pylon_model(name, x, y, z, height, collision=True):
     )
 
 
+def _wrap_group(group_name, model_lists):
+    """Wrap non-empty model lists into a nested container model.
+
+    Args:
+        group_name: Name for the top-level container (e.g. 's57_features').
+        model_lists: dict mapping type name to list of model XML strings.
+
+    Returns:
+        SDF string for the container model, or empty string if all empty.
+    """
+    type_groups = []
+    for type_name, models in model_lists.items():
+        if not models:
+            continue
+        inner = '\n'.join(f'  {line}' for m in models for line in m.split('\n'))
+        type_groups.append(
+            f'      <model name="{type_name}">\n'
+            f'{inner}\n'
+            f'      </model>'
+        )
+    if not type_groups:
+        return ''
+    inner_xml = '\n'.join(type_groups)
+    return (
+        f'    <model name="{group_name}">\n'
+        f'      <static>true</static>\n'
+        f'{inner_xml}\n'
+        f'    </model>'
+    )
+
+
 def generate_feature_models(
     features, center_lat, center_lon,
     terrain=None, terrain_bounds=None, debug=False,
     skip_categories=None, simplify_tolerance=0.0,
     max_wall_segments=None,
 ):
-    """Convert S57 features to SDF <model> XML strings.
+    """Convert S57 features to grouped SDF <model> XML strings.
+
+    Features are organized into two top-level container models:
+    ``s57_features`` and ``osm_features``, each containing sub-groups
+    by feature type. This creates a 3-level hierarchy in Gazebo's
+    Entity Tree: source -> feature type -> individual models.
 
     Args:
         features: S57Features instance with extracted chart features.
@@ -879,15 +915,19 @@ def generate_feature_models(
             generation.  0 disables simplification.
 
     Returns:
-        String of SDF <model> elements ready to insert into a world template.
-        Empty string if no features to generate.
+        Dict with 's57' and 'osm' keys, each containing an SDF string
+        for the corresponding container model. Values are empty strings
+        if no features to generate for that source.
     """
-    models = []
     skip = skip_categories or set()
 
     # Land features omit collision geometry — they exist for visual context
     # only and don't need physics interaction with vessels.
     _LAND = False
+
+    # Collect models by type for S57 and OSM sources
+    s57_buildings = []
+    osm_buildings = []
 
     # Buildings (BUISGL, LNDMRK, SILTNK)
     for i, building in enumerate(
@@ -927,9 +967,13 @@ def generate_feature_models(
             ambient=amb, diffuse=dif, collision=_LAND,
         )
         if model:
-            models.append(model)
+            if building.osm_only:
+                osm_buildings.append(model)
+            else:
+                s57_buildings.append(model)
 
     # Pontoons (water surface, z=0)
+    pontoons = []
     for i, pontoon in enumerate(
         features.pontoons if 'pontoons' not in skip else []
     ):
@@ -948,7 +992,7 @@ def generate_feature_models(
                 ambient=amb, diffuse=dif,
             )
             if model:
-                models.append(model)
+                pontoons.append(model)
         elif geom_type in (2, 5, 7):  # LineString, Multi, Collection
             wall, _ = _slcons_wall_model(
                 f'pontoon_{i:04d}', pontoon.geometry,
@@ -957,9 +1001,10 @@ def generate_feature_models(
                 ambient=amb, diffuse=dif,
             )
             if wall:
-                models.append(wall)
+                pontoons.append(wall)
 
     # Bridges (deck at clearance height, not extruded from 0)
+    bridges = []
     for i, bridge in enumerate(
         features.bridges if 'bridges' not in skip else []
     ):
@@ -980,7 +1025,7 @@ def generate_feature_models(
                 ambient=amb, diffuse=dif,
             )
             if model:
-                models.append(model)
+                bridges.append(model)
         elif geom_type in (2, 5, 7):  # LineString, Multi, Collection
             wall, _ = _slcons_wall_model(
                 f'bridge_{i:04d}', bridge.geometry,
@@ -989,16 +1034,18 @@ def generate_feature_models(
                 ambient=amb, diffuse=dif,
             )
             if wall:
-                models.append(wall)
+                bridges.append(wall)
 
     # Buoys (water surface, z=0)
+    buoys = []
     for i, buoy in enumerate(
         features.buoys if 'buoys' not in skip else []
     ):
         x, y = _latlon_to_enu(buoy.lat, buoy.lon, center_lat, center_lon)
-        models.append(_buoy_model(f'buoy_{i:04d}', x, y, buoy.colour))
+        buoys.append(_buoy_model(f'buoy_{i:04d}', x, y, buoy.colour))
 
     # Beacons (on terrain)
+    beacons = []
     for i, beacon in enumerate(
         features.beacons if 'beacons' not in skip else []
     ):
@@ -1006,12 +1053,13 @@ def generate_feature_models(
             beacon.lat, beacon.lon, center_lat, center_lon
         )
         z = _sample_terrain_elevation(x, y, terrain, terrain_bounds)
-        models.append(_beacon_model(
+        beacons.append(_beacon_model(
             f'beacon_{i:04d}', x, y, z=z, colour_code=beacon.colour,
             collision=_LAND,
         ))
 
     # Lights (on terrain)
+    lights = []
     for i, light in enumerate(
         features.lights if 'lights' not in skip else []
     ):
@@ -1019,12 +1067,13 @@ def generate_feature_models(
             light.lat, light.lon, center_lat, center_lon
         )
         z = _sample_terrain_elevation(x, y, terrain, terrain_bounds)
-        models.append(_light_model(f'light_{i:04d}', x, y, z=z,
+        lights.append(_light_model(f'light_{i:04d}', x, y, z=z,
                                    tower_height=light.height,
                                    colour_code=light.colour,
                                    collision=_LAND))
 
     # Shore constructions (SLCONS): line, polygon, and point geometry
+    shore_constructions = []
     wall_seg_remaining = max_wall_segments
     for i, sc in enumerate(
         features.shore_constructions if 'shore_constructions' not in skip
@@ -1048,7 +1097,7 @@ def generate_feature_models(
                 seg_budget=wall_seg_remaining,
             )
             if wall:
-                models.append(wall)
+                shore_constructions.append(wall)
             if wall_seg_remaining is not None:
                 wall_seg_remaining -= n_segs
         elif geom_type in (3, 6):  # Polygon, MultiPolygon
@@ -1058,33 +1107,36 @@ def generate_feature_models(
                 ambient=amb, diffuse=dif, collision=_LAND,
             )
             if model:
-                models.append(model)
+                shore_constructions.append(model)
         elif geom_type == 1:  # Point
             x, y = _latlon_to_enu(
                 sc.geometry.GetY(), sc.geometry.GetX(),
                 center_lat, center_lon,
             )
-            models.append(_slcons_point_model(f'slcons_{i:04d}', x, y,
-                                               collision=_LAND))
+            shore_constructions.append(_slcons_point_model(
+                f'slcons_{i:04d}', x, y, collision=_LAND))
 
     # Piles (at water level)
+    piles = []
     for i, pile in enumerate(
         features.piles if 'piles' not in skip else []
     ):
         x, y = _latlon_to_enu(pile.lat, pile.lon, center_lat, center_lon)
-        models.append(_pile_model(f'pile_{i:04d}', x, y))
+        piles.append(_pile_model(f'pile_{i:04d}', x, y))
 
     # Mooring facilities
+    mooring_facilities = []
     for i, mf in enumerate(
         features.mooring_facilities if 'mooring_facilities' not in skip
         else []
     ):
         x, y = _latlon_to_enu(mf.lat, mf.lon, center_lat, center_lon)
         z = _sample_terrain_elevation(x, y, terrain, terrain_bounds)
-        models.append(_morfac_model(f'morfac_{i:04d}', x, y, z, mf.catmor,
-                                    collision=_LAND))
+        mooring_facilities.append(_morfac_model(
+            f'morfac_{i:04d}', x, y, z, mf.catmor, collision=_LAND))
 
     # Cranes (on terrain)
+    cranes = []
     for i, crane in enumerate(
         features.cranes if 'cranes' not in skip else []
     ):
@@ -1092,12 +1144,13 @@ def generate_feature_models(
             crane.lat, crane.lon, center_lat, center_lon
         )
         z = _sample_terrain_elevation(x, y, terrain, terrain_bounds)
-        models.append(_crane_model(
+        cranes.append(_crane_model(
             f'crane_{i:04d}', x, y, z, crane.catcrn, crane.height,
             collision=_LAND,
         ))
 
     # Pylons (on terrain)
+    pylons = []
     for i, pylon in enumerate(
         features.pylons if 'pylons' not in skip else []
     ):
@@ -1105,12 +1158,13 @@ def generate_feature_models(
             pylon.lat, pylon.lon, center_lat, center_lon
         )
         z = _sample_terrain_elevation(x, y, terrain, terrain_bounds)
-        models.append(_pylon_model(
+        pylons.append(_pylon_model(
             f'pylon_{i:04d}', x, y, z, pylon.height,
             collision=_LAND,
         ))
 
     # Debug: coastline walls (simplified to reduce segment count)
+    coastlines = []
     if debug and features.coastlines:
         for i, coastline in enumerate(features.coastlines):
             tol = simplify_tolerance if simplify_tolerance > 0 else 0.0002
@@ -1120,9 +1174,28 @@ def generate_feature_models(
                 center_lat, center_lon,
             )
             if wall:
-                models.append(wall)
+                coastlines.append(wall)
 
-    if not models:
-        return ''
+    # Build grouped container models
+    s57_types = {
+        'buildings': s57_buildings,
+        'pontoons': pontoons,
+        'bridges': bridges,
+        'buoys': buoys,
+        'beacons': beacons,
+        'lights': lights,
+        'shore_constructions': shore_constructions,
+        'piles': piles,
+        'mooring_facilities': mooring_facilities,
+        'cranes': cranes,
+        'pylons': pylons,
+        'coastlines': coastlines,
+    }
+    osm_types = {
+        'buildings': osm_buildings,
+    }
 
-    return '\n\n'.join(models)
+    return {
+        's57': _wrap_group('s57_features', s57_types),
+        'osm': _wrap_group('osm_features', osm_types),
+    }

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/generate_world.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/generate_world.py
@@ -374,7 +374,8 @@ def main(argv=None):
         heightmap_result = heightmap_info
 
     # Step 5: Generate feature models (optional)
-    feature_sdf = ""
+    s57_feature_sdf = ""
+    osm_feature_sdf = ""
     skip_categories = set()
     if args.skip_categories:
         skip_categories = {c.strip() for c in args.skip_categories.split(',')}
@@ -400,8 +401,8 @@ def main(argv=None):
         }
 
     if not args.no_features and s57_features is not None:
-        print("Generating S57 feature models...")
-        feature_sdf = generate_feature_models(
+        print("Generating feature models...")
+        feature_groups = generate_feature_models(
             s57_features, ref_lat, ref_lon,
             terrain=first_terrain, terrain_bounds=terrain_bounds,
             debug=args.debug_features,
@@ -409,8 +410,11 @@ def main(argv=None):
             simplify_tolerance=simplify_tol,
             max_wall_segments=args.max_wall_segments,
         )
-        if feature_sdf:
-            n_models = feature_sdf.count("<model name=")
+        s57_feature_sdf = feature_groups['s57']
+        osm_feature_sdf = feature_groups['osm']
+        total = s57_feature_sdf + osm_feature_sdf
+        if total:
+            n_models = total.count("<model name=")
             print(f"  Generated {n_models} feature models")
         else:
             print("  No placeable features found")
@@ -431,7 +435,8 @@ def main(argv=None):
         output_dir=args.output_dir,
         heightmap_info=heightmap_result,
         camera_config=camera_config or None,
-        feature_models=feature_sdf,
+        s57_feature_models=s57_feature_sdf,
+        osm_feature_models=osm_feature_sdf,
         water_size_x=water_x,
         water_size_y=water_y,
     )

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_matcher.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_matcher.py
@@ -150,6 +150,7 @@ def match_and_enrich(
             osm_height=osm_height,
             osm_material=osm_building.material,
             osm_colour=osm_building.colour,
+            osm_only=True,
         ))
         n_added += 1
 

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/s57_reader.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/s57_reader.py
@@ -86,6 +86,7 @@ class Building:
     osm_height: Optional[float] = None  # from OSM height or levels*3
     osm_material: str = ''  # from OSM building:material
     osm_colour: str = ''  # from OSM building:colour
+    osm_only: bool = False  # True if building came from OSM with no S57 match
 
 
 @dataclass

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/world_builder.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/world_builder.py
@@ -128,7 +128,8 @@ def generate_world_sdf(
     output_dir: str,
     heightmap_info,
     camera_config: dict = None,
-    feature_models: str = "",
+    s57_feature_models: str = "",
+    osm_feature_models: str = "",
     water_size_x: float = 0.0,
     water_size_y: float = 0.0,
 ) -> str:
@@ -141,7 +142,7 @@ def generate_world_sdf(
     - Terrain heightmap model(s)
     - Semi-transparent water surface plane
     - Scene with sky and lighting
-    - Optional S57 chart feature models (buildings, buoys, etc.)
+    - Optional S57/OSM chart feature models (buildings, buoys, etc.)
 
     Args:
         world_name: Name for the world (used in filename and SDF).
@@ -151,7 +152,8 @@ def generate_world_sdf(
         heightmap_info: dict from terrain_to_heightmap() for single tile,
             or list of dicts for multi-tile.
         camera_config: optional dict with camera overrides (see _compute_camera).
-        feature_models: SDF model XML strings for S57 features (default empty).
+        s57_feature_models: SDF XML for S57-sourced features (default empty).
+        osm_feature_models: SDF XML for OSM-sourced features (default empty).
         water_size_x: Override water plane width (meters). If 0, uses
             heightmap_info size.
         water_size_y: Override water plane height (meters). If 0, uses
@@ -189,7 +191,8 @@ def generate_world_sdf(
         terrain_includes=terrain_includes,
         camera_pose=camera_pose,
         camera_far=camera_far,
-        feature_models=feature_models,
+        s57_feature_models=s57_feature_models,
+        osm_feature_models=osm_feature_models,
     )
 
     sdf_path = os.path.join(output_dir, f"{world_name}.sdf")

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/world_template.sdf.xml
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/world_template.sdf.xml
@@ -237,7 +237,9 @@
       </link>
     </model>
 
-{feature_models}
+{s57_feature_models}
+
+{osm_feature_models}
 
   </world>
 </sdf>

--- a/marine_charts_to_gazebo_world/test/test_feature_models.py
+++ b/marine_charts_to_gazebo_world/test/test_feature_models.py
@@ -38,6 +38,13 @@ CENTER_LAT = 43.075
 CENTER_LON = -70.71
 
 
+def _all_features_sdf(features, *args, **kwargs):
+    """Call generate_feature_models and join s57+osm output."""
+    result = generate_feature_models(features, *args, **kwargs)
+    parts = [v for v in (result['s57'], result['osm']) if v]
+    return '\n\n'.join(parts)
+
+
 def _make_polygon(coords):
     """Create an OGR polygon from a list of (lon, lat) tuples."""
     ring = ogr.Geometry(ogr.wkbLinearRing)
@@ -78,10 +85,10 @@ class TestLatLonToEnu:
 class TestGenerateFeatureModelsEmpty:
 
     def test_empty_features(self):
-        """Empty features should return empty string."""
+        """Empty features should return dict with empty strings."""
         features = S57Features()
         result = generate_feature_models(features, CENTER_LAT, CENTER_LON)
-        assert result == ''
+        assert result == {'s57': '', 'osm': ''}
 
 
 class TestBuildingModel:
@@ -95,14 +102,15 @@ class TestBuildingModel:
             (-70.711, 43.077),
         ])
         features = S57Features(buildings=[Building(geometry=poly, objl=12)])
-        result = generate_feature_models(features, CENTER_LAT, CENTER_LON)
+        result = _all_features_sdf(features, CENTER_LAT, CENTER_LON)
         assert '<model name="building_0000">' in result
         assert '<polyline>' in result
         assert '<height>5.0</height>' in result
-        # Should be valid XML when wrapped
+        # Should be valid XML when wrapped — building is nested inside
+        # s57_features/buildings container
         root = ET.fromstring(f'<root>{result}</root>')
-        models = root.findall('model')
-        assert len(models) == 1
+        buildings = root.findall('.//model[@name="building_0000"]')
+        assert len(buildings) == 1
 
     def test_landmark_height(self):
         """LNDMRK (OBJL 73) should use 12.0m height."""
@@ -113,7 +121,7 @@ class TestBuildingModel:
             (-70.711, 43.077),
         ])
         features = S57Features(buildings=[Building(geometry=poly, objl=73)])
-        result = generate_feature_models(features, CENTER_LAT, CENTER_LON)
+        result = _all_features_sdf(features, CENTER_LAT, CENTER_LON)
         assert '<height>12.0</height>' in result
 
     def test_silo_height(self):
@@ -125,7 +133,7 @@ class TestBuildingModel:
             (-70.711, 43.077),
         ])
         features = S57Features(buildings=[Building(geometry=poly, objl=119)])
-        result = generate_feature_models(features, CENTER_LAT, CENTER_LON)
+        result = _all_features_sdf(features, CENTER_LAT, CENTER_LON)
         assert '<height>8.0</height>' in result
 
 
@@ -143,7 +151,7 @@ class TestBuildingObjnam:
             buildings=[Building(geometry=poly, objl=12,
                                 objnam='Coast Guard Station')]
         )
-        result = generate_feature_models(features, CENTER_LAT, CENTER_LON)
+        result = _all_features_sdf(features, CENTER_LAT, CENTER_LON)
         assert '<model name="building_0000_coast_guard_station">' in result
 
     def test_empty_objnam_uses_default(self):
@@ -157,7 +165,7 @@ class TestBuildingObjnam:
         features = S57Features(
             buildings=[Building(geometry=poly, objl=12, objnam='')]
         )
-        result = generate_feature_models(features, CENTER_LAT, CENTER_LON)
+        result = _all_features_sdf(features, CENTER_LAT, CENTER_LON)
         assert '<model name="building_0000">' in result
 
     def test_special_chars_sanitized(self):
@@ -172,7 +180,7 @@ class TestBuildingObjnam:
             buildings=[Building(geometry=poly, objl=12,
                                 objnam='Bldg #42 (Main)')]
         )
-        result = generate_feature_models(features, CENTER_LAT, CENTER_LON)
+        result = _all_features_sdf(features, CENTER_LAT, CENTER_LON)
         assert '<model name="building_0000_bldg_42_main">' in result
 
 
@@ -203,7 +211,7 @@ class TestPontoonModel:
             (-70.711, 43.077),
         ])
         features = S57Features(pontoons=[Pontoon(geometry=poly)])
-        result = generate_feature_models(features, CENTER_LAT, CENTER_LON)
+        result = _all_features_sdf(features, CENTER_LAT, CENTER_LON)
         assert '<model name="pontoon_0000">' in result
         assert '<height>1.0</height>' in result
 
@@ -221,7 +229,7 @@ class TestBridgeModel:
         features = S57Features(
             bridges=[Bridge(geometry=poly, clearance=15.0)]
         )
-        result = generate_feature_models(features, CENTER_LAT, CENTER_LON)
+        result = _all_features_sdf(features, CENTER_LAT, CENTER_LON)
         assert '<model name="bridge_0000">' in result
         # Deck thickness is 1.0m, placed at z=15.0
         assert '<height>1.0</height>' in result
@@ -236,7 +244,7 @@ class TestBridgeModel:
             (-70.711, 43.077),
         ])
         features = S57Features(bridges=[Bridge(geometry=poly, clearance=0.0)])
-        result = generate_feature_models(features, CENTER_LAT, CENTER_LON)
+        result = _all_features_sdf(features, CENTER_LAT, CENTER_LON)
         # Deck at z=10.0 with 1.0m thickness
         assert '<height>1.0</height>' in result
         assert '10.00 0 0 0' in result
@@ -249,19 +257,19 @@ class TestBuoyModel:
         features = S57Features(
             buoys=[Buoy(lat=43.076, lon=-70.711, colour=3)]
         )
-        result = generate_feature_models(features, CENTER_LAT, CENTER_LON)
+        result = _all_features_sdf(features, CENTER_LAT, CENTER_LON)
         assert '<model name="buoy_0000">' in result
         assert '<cylinder>' in result
         assert '<cone>' in result
         root = ET.fromstring(f'<root>{result}</root>')
-        assert len(root.findall('model')) == 1
+        assert len(root.findall('.//model[@name="buoy_0000"]')) == 1
 
     def test_buoy_red_colour(self):
         """Buoy with COLOUR=3 (red) should have red material."""
         features = S57Features(
             buoys=[Buoy(lat=43.076, lon=-70.711, colour=3)]
         )
-        result = generate_feature_models(features, CENTER_LAT, CENTER_LON)
+        result = _all_features_sdf(features, CENTER_LAT, CENTER_LON)
         # Red: 1.0 0.0 0.0
         assert '1.0 0.0 0.0 1.0' in result
 
@@ -270,7 +278,7 @@ class TestBuoyModel:
         features = S57Features(
             buoys=[Buoy(lat=43.076, lon=-70.711, colour=4)]
         )
-        result = generate_feature_models(features, CENTER_LAT, CENTER_LON)
+        result = _all_features_sdf(features, CENTER_LAT, CENTER_LON)
         assert '0.0 0.8 0.0 1.0' in result
 
     def test_buoy_unknown_colour_defaults_yellow(self):
@@ -278,7 +286,7 @@ class TestBuoyModel:
         features = S57Features(
             buoys=[Buoy(lat=43.076, lon=-70.711, colour=99)]
         )
-        result = generate_feature_models(features, CENTER_LAT, CENTER_LON)
+        result = _all_features_sdf(features, CENTER_LAT, CENTER_LON)
         assert '1.0 1.0 0.0 1.0' in result
 
 
@@ -289,11 +297,11 @@ class TestBeaconModel:
         features = S57Features(
             beacons=[Beacon(lat=43.076, lon=-70.711)]
         )
-        result = generate_feature_models(features, CENTER_LAT, CENTER_LON)
+        result = _all_features_sdf(features, CENTER_LAT, CENTER_LON)
         assert '<model name="beacon_0000">' in result
         assert '<cylinder>' in result
         root = ET.fromstring(f'<root>{result}</root>')
-        assert len(root.findall('model')) == 1
+        assert len(root.findall('.//model[@name="beacon_0000"]')) == 1
 
 
 class TestLightModel:
@@ -303,12 +311,12 @@ class TestLightModel:
         features = S57Features(
             lights=[Light(lat=43.076, lon=-70.711)]
         )
-        result = generate_feature_models(features, CENTER_LAT, CENTER_LON)
+        result = _all_features_sdf(features, CENTER_LAT, CENTER_LON)
         assert '<model name="light_0000">' in result
         assert '<cylinder>' in result
         assert '<sphere>' in result
         root = ET.fromstring(f'<root>{result}</root>')
-        assert len(root.findall('model')) == 1
+        assert len(root.findall('.//model[@name="light_0000"]')) == 1
 
 
 class TestMultipleFeatures:
@@ -326,9 +334,12 @@ class TestMultipleFeatures:
             buoys=[Buoy(lat=43.076, lon=-70.711, colour=3)],
             lights=[Light(lat=43.076, lon=-70.712)],
         )
-        result = generate_feature_models(features, CENTER_LAT, CENTER_LON)
+        result = _all_features_sdf(features, CENTER_LAT, CENTER_LON)
         assert 'building_0000' in result
         assert 'buoy_0000' in result
         assert 'light_0000' in result
         root = ET.fromstring(f'<root>{result}</root>')
-        assert len(root.findall('model')) == 3
+        # Top-level container is s57_features; individual features are nested
+        assert len(root.findall('.//model[@name="building_0000"]')) == 1
+        assert len(root.findall('.//model[@name="buoy_0000"]')) == 1
+        assert len(root.findall('.//model[@name="light_0000"]')) == 1

--- a/marine_charts_to_gazebo_world/test/test_world_builder.py
+++ b/marine_charts_to_gazebo_world/test/test_world_builder.py
@@ -165,7 +165,7 @@ class TestGenerateWorldSdf:
                 center_lon=-70.71,
                 output_dir=tmpdir,
                 heightmap_info=heightmap_info,
-                feature_models=feature_xml,
+                s57_feature_models=feature_xml,
             )
             with open(sdf_path) as f:
                 content = f.read()

--- a/portsmouth_nh_gazebo/CMakeLists.txt
+++ b/portsmouth_nh_gazebo/CMakeLists.txt
@@ -75,6 +75,9 @@ add_gazebo_world(portsmouth_nh_isles_of_shoals
 add_gazebo_world(portsmouth_nh_portsmouth_to_isles
   "${CMAKE_CURRENT_SOURCE_DIR}/config/portsmouth_to_isles.yaml")
 
+add_gazebo_world(portsmouth_nh_unh_pier
+  "${CMAKE_CURRENT_SOURCE_DIR}/config/unh_pier.yaml")
+
 # ---------- Install ----------
 
 # Launch files

--- a/portsmouth_nh_gazebo/config/unh_pier.yaml
+++ b/portsmouth_nh_gazebo/config/unh_pier.yaml
@@ -1,0 +1,13 @@
+bounds:
+  south: 43.069694
+  west: -70.7148459
+  north: 43.0727356
+  east: -70.7067844
+
+world_name: portsmouth_nh_unh_pier
+
+grid_power: 10   # 1025x1025 (~0.35 m/cell for this small area)
+
+osm: true
+# No skip_categories — show all features
+# No no_osm_buildings — include OSM-only buildings too

--- a/portsmouth_nh_gazebo/launch/unh_pier_launch.py
+++ b/portsmouth_nh_gazebo/launch/unh_pier_launch.py
@@ -1,0 +1,59 @@
+# Copyright 2025 Roland Arsenault
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Launch Gazebo with the UNH Pier world."""
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import (
+    DeclareLaunchArgument,
+    ExecuteProcess,
+    OpaqueFunction,
+    Shutdown,
+)
+from launch.substitutions import LaunchConfiguration
+
+WORLD_NAME = 'portsmouth_nh_unh_pier'
+
+
+def _launch_gazebo(context, *args, **kwargs):
+    verbose = LaunchConfiguration('verbose').perform(context) == 'true'
+    pkg_share = get_package_share_directory('portsmouth_nh_gazebo')
+    sdf_path = os.path.join(
+        pkg_share, 'worlds', WORLD_NAME, f'{WORLD_NAME}.sdf'
+    )
+    if not os.path.exists(sdf_path):
+        raise RuntimeError(
+            f'World SDF not found at {sdf_path}. '
+            'Rebuild: colcon build --packages-select portsmouth_nh_gazebo'
+        )
+    return [
+        ExecuteProcess(
+            cmd=['gz', 'sim', '-v4' if verbose else '-v1', sdf_path],
+            output='screen',
+            on_exit=Shutdown(),
+        ),
+    ]
+
+
+def generate_launch_description():
+    return LaunchDescription([
+        DeclareLaunchArgument(
+            'verbose', default_value='false',
+            description='Enable verbose Gazebo output',
+        ),
+        OpaqueFunction(function=_launch_gazebo),
+    ])


### PR DESCRIPTION
## Summary

- Group generated SDF feature models into nested containers (`s57_features` / `osm_features` → feature type → individual models) for togglable visibility in Gazebo's Entity Tree
- Add `osm_only` flag to `Building` dataclass to distinguish OSM-only buildings from S57 buildings
- Add `unh_pier` world (43.069694,-70.7148459 to 43.0727356,-70.7067844) with all data sources enabled

## Test plan

- [x] `marine_charts_to_gazebo_world` builds and all 75 tests pass
- [x] `portsmouth_nh_gazebo` builds successfully (all 4 worlds generated)
- [x] Generated harbor SDF contains `s57_features` container with type sub-groups
- [x] Generated unh_pier SDF contains both `s57_features` and `osm_features` containers
- [ ] Launch harbor world: verify features appear grouped in Entity Tree
- [ ] Launch unh_pier world: verify it generates and loads correctly
- [ ] Toggle visibility of each group in Entity Tree

Closes #37

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
