### PR TITLE
Enhance world generation with OSM terrain, pier polygons, and gangways

### DIFF
--- a/marine_charts_to_gazebo_world/TERRAIN_TEXTURE_PIPELINE.md
+++ b/marine_charts_to_gazebo_world/TERRAIN_TEXTURE_PIPELINE.md
@@ -1,0 +1,220 @@
+# Terrain Texture Pipeline
+
+How OSM features are rasterized onto a texture image and applied to a
+Gazebo OGRE2 heightmap.  This document exists because the coordinate
+mapping between the rasterizer and Gazebo's UV system is subtle and
+has been a recurring source of bugs.
+
+## Pipeline Overview
+
+```
+OSM data (lat/lon)
+    │
+    ▼
+osm_texture.py ── rasterize_osm_texture()
+    │  Converts lat/lon → ENU → pixel coordinates
+    │  Draws features onto a PIL Image (grid_size × grid_size)
+    ▼
+land_diffuse.png  (square image, 1025×1025 for grid_power=10)
+    │
+    ▼
+heightmap.py ── _write_model_sdf()
+    │  Embeds texture in SDF <heightmap> with <texture><size>
+    ▼
+Gazebo OGRE2 renderer
+    │  Maps texture onto heightmap using UV coordinates
+    ▼
+Visible terrain in simulation
+```
+
+## Coordinate Systems
+
+### ENU (East-North-Up)
+
+All 3D positioning uses a local ENU frame centered at `(ref_lat, ref_lon)`,
+which is the bounding box center.  East is +X, North is +Y.
+
+- `terrain.py` builds the elevation grid in ENU.
+- `feature_models.py` places 3D models in ENU.
+- `osm_texture.py` converts features to ENU before rasterizing.
+
+### Heightmap Image
+
+The heightmap PNG is written north-up:
+
+- **Row 0** = north edge of the bounding box
+- **Last row** = south edge
+- **Column 0** = west edge
+- **Last column** = east edge
+
+### Texture Image
+
+The texture PNG uses the same orientation as the heightmap:
+
+- **Row 0** = north edge
+- **Last row** = south edge (or unused padding for non-square extents)
+
+## Gazebo OGRE2 UV Mapping
+
+This is the critical part that caused repeated bugs.
+
+### How `<texture><size>` Works
+
+The SDF heightmap element accepts a `<size>` parameter per texture layer:
+
+```xml
+<texture>
+  <diffuse>land_diffuse.png</diffuse>
+  <size>656.6</size>          <!-- single value: meters per tile -->
+</texture>
+<size>656.6 337.9 19.6</size>  <!-- heightmap X Y Z extent -->
+```
+
+The texture `<size>` is a **single scalar** — it controls how many world
+meters one full texture tile covers in **both** U and V.  It does NOT
+accept separate U/V values.
+
+### UV Coordinate Range
+
+For a heightmap of size `(size_x, size_y)` with texture tiling at
+`tex_size` meters:
+
+| Axis | UV range | Meaning |
+|------|----------|---------|
+| U | `[0, size_x / tex_size]` | West to east |
+| V | `[0, size_y / tex_size]` | North to south |
+
+**OGRE2 maps image row 0 to V=0 (north), with V increasing southward.**
+This matches the heightmap image orientation (row 0 = north).
+
+### Non-Square Heightmaps
+
+When `size_x ≠ size_y`, only a portion of the texture image is used:
+
+- `tex_size = max(size_x, size_y)` to prevent any axis from tiling/wrapping.
+- U spans `[0, size_x / tex_size]` — full width if `size_x = tex_size`.
+- V spans `[0, size_y / tex_size]` — partial height if `size_y < tex_size`.
+
+**Example**: A 656.6m × 337.9m heightmap with `tex_size = 656.6`:
+- U range: `[0, 1.0]` — full image width
+- V range: `[0, 0.515]` — top 51.5% of image height
+- Features must be rasterized into the **top-left** portion of the image.
+- The bottom ~48.5% of the image is unused (base land color).
+
+## Pixel Mapping Formula
+
+The rasterizer converts ENU coordinates to pixel positions:
+
+```python
+# East ∈ [-size_x/2, +size_x/2]  →  pixel column [0, grid_size-1 * size_x/tex_size]
+px = (east + size_x / 2) / tex_size * (grid_size - 1)
+
+# North ∈ [-size_y/2, +size_y/2]  →  pixel row [0, grid_size-1 * size_y/tex_size]
+# Row 0 = north edge, row increases southward (matching OGRE2 V direction)
+py = (size_y / 2 - north) / tex_size * (grid_size - 1)
+```
+
+### Why Not Simply `(grid_size-1) - north_normalized`?
+
+The naive formula `py = (grid_size-1) - (north + size_y/2) / size_y * (grid_size-1)`
+spreads features across the full image height.  But Gazebo only samples the
+top `size_y / tex_size` fraction.  Dividing by `tex_size` instead of `size_y`
+compresses features into that fraction.
+
+## Common Pitfalls
+
+### 1. Dividing Y by `size_y` Instead of `tex_size`
+
+**Symptom**: Texture appears displaced ~100–200 m south of the 3D models.
+
+The pixel Y formula must divide by `tex_size`, not `size_y`.  When
+`size_x > size_y` (wide heightmap), dividing by `size_y` stretches features
+across the full image height, but Gazebo only reads the top portion.
+Features that should appear at the heightmap center end up in the bottom
+half of the image where Gazebo doesn't look.
+
+### 2. Assuming V=0 is at the South (OpenGL Convention)
+
+**Symptom**: Texture is invisible or vertically flipped.
+
+OpenGL's texture convention has V=0 at the bottom, but OGRE2's heightmap
+texture mapping has V=0 at image row 0 (north/top).  Do NOT flip the image
+or invert the Y formula to put south at row 0.
+
+### 3. Flipping the Image with `FLIP_TOP_BOTTOM`
+
+**Symptom**: Texture appears but is vertically mirrored.
+
+The terrain grid and texture rasterizer both use north-at-row-0.  Adding
+a vertical flip makes them inconsistent.
+
+### 4. Using `size_x` for Texture `<size>` on Tall Heightmaps
+
+**Symptom**: Texture wraps/tiles in the V direction.
+
+If `size_y > size_x`, then `V_max = size_y / size_x > 1.0`, causing the
+texture to tile.  Always use `tex_size = max(size_x, size_y)`.
+
+## Debugging Texture Alignment
+
+### Quick Visual Check
+
+1. Build the world: `./simulation_ws/build.sh portsmouth_nh_gazebo`
+2. Open the texture PNG directly — features should be in the **top-left**
+   corner for wide heightmaps (size_x > size_y).
+3. Launch in Gazebo and compare feature positions (roads, landuse boundaries)
+   against the 3D building models.
+4. If the texture is displaced but 3D models are correct, the bug is in the
+   texture pipeline (not the OSM data or ENU conversion).
+
+### Comparing Texture vs 3D Models
+
+The 3D feature models (`feature_models.py`) and the texture rasterizer
+(`osm_texture.py`) both consume the same OSM data and use the same ENU
+conversion.  If 3D models are correctly positioned but the texture is
+offset, the problem is always in:
+
+1. The pixel mapping formula in `_latlon_to_pixel()`
+2. The `tex_size` value passed to the rasterizer
+3. The `<texture><size>` value in the SDF
+
+### Inspecting SDF Values
+
+Check the generated `model.sdf` in the build output:
+
+```bash
+cat simulation_ws/build/portsmouth_nh_gazebo/worlds/<world>/<world>_terrain/model.sdf
+```
+
+Verify:
+- `<size>X Y Z</size>` matches the expected heightmap extent in meters.
+- `<texture><size>` equals `max(X, Y)` (not just `X`).
+- `<pos>` is `0 0 min_elev` for single-tile worlds.
+
+### Clearing Caches
+
+OSM data is cached.  After changing the Overpass query, bump the cache
+key version in `osm_fetcher.py` (`_cache_key()` prefix) and delete stale
+cache files:
+
+```bash
+rm ~/.cache/marine_charts_to_gazebo_world/osm_terrain_*
+```
+
+Also delete the build artifacts to force world regeneration:
+
+```bash
+rm -rf simulation_ws/build/portsmouth_nh_gazebo/worlds/<world>
+rm -rf simulation_ws/install/portsmouth_nh_gazebo/share/portsmouth_nh_gazebo/worlds/<world>
+```
+
+## File Reference
+
+| File | Role |
+|------|------|
+| `osm_texture.py` | Rasterizes OSM features to texture image |
+| `terrain.py` | Builds elevation grid in ENU |
+| `heightmap.py` | Writes heightmap PNG + SDF (including texture `<size>`) |
+| `generate_world.py` | Orchestrates pipeline, passes `tex_size` between stages |
+| `feature_models.py` | Generates 3D SDF models (independent of texture) |
+| `osm_fetcher.py` | Fetches/caches OSM data from Overpass API |

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/feature_models.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/feature_models.py
@@ -1218,7 +1218,7 @@ def generate_feature_models(
             if wall:
                 marine_models.append(wall)
 
-    # Roads from OSM (flat strips for debugging)
+    # Roads from OSM (dashed debug markers floating above terrain)
     _ROAD_WIDTHS = {
         'motorway': 12.0, 'trunk': 10.0, 'primary': 9.0,
         'secondary': 8.0, 'tertiary': 7.0, 'residential': 6.0,
@@ -1227,17 +1227,71 @@ def generate_feature_models(
     }
     _ROAD_AMB = '0.3 0.3 0.3 1.0'
     _ROAD_DIF = '0.4 0.4 0.4 1.0'
+    _ROAD_DASH_LEN = 5.0    # meters per dash segment
+    _ROAD_DASH_GAP = 50.0   # meters between dash starts
+    _ROAD_HEIGHT = 0.15     # dash thickness
+    _ROAD_Z = 5.0           # float above terrain for debug visibility
     road_models = []
+    road_seg_idx = 0
     for i, road in enumerate(osm_roads or []):
         width = _ROAD_WIDTHS.get(road.highway, 4.0)
-        wall, _ = _slcons_wall_model(
-            f'road_{i:04d}_{road.highway}', road.geometry,
-            center_lat, center_lon,
-            height=0.15, wall_width=width, z=0.1,
-            ambient=_ROAD_AMB, diffuse=_ROAD_DIF, collision=False,
-        )
-        if wall:
-            road_models.append(wall)
+        geom_type = road.geometry.GetGeometryType() & 0xFF
+        lines = []
+        if geom_type == 2:
+            lines = [road.geometry]
+        elif geom_type == 5:
+            lines = [road.geometry.GetGeometryRef(j)
+                     for j in range(road.geometry.GetGeometryCount())]
+        for line in lines:
+            # Walk along the linestring, placing dashes at intervals
+            n = line.GetPointCount()
+            if n < 2:
+                continue
+            # Build ENU points for the line
+            pts = []
+            for pi in range(n):
+                lon, lat = line.GetX(pi), line.GetY(pi)
+                x, y = _latlon_to_enu(lat, lon, center_lat, center_lon)
+                pts.append((x, y))
+            # Walk along cumulative distance, emit dashes
+            dist_since_dash = 0.0
+            for pi in range(len(pts) - 1):
+                x0, y0 = pts[pi]
+                x1, y1 = pts[pi + 1]
+                dx, dy = x1 - x0, y1 - y0
+                seg_len = math.sqrt(dx * dx + dy * dy)
+                if seg_len < 0.1:
+                    continue
+                dist_since_dash += seg_len
+                if dist_since_dash >= _ROAD_DASH_GAP:
+                    dist_since_dash = 0.0
+                    mx = (x0 + x1) / 2.0
+                    my = (y0 + y1) / 2.0
+                    yaw = math.atan2(dy, dx)
+                    dash_len = min(_ROAD_DASH_LEN, seg_len)
+                    road_models.append(
+                        f'    <model name="road_{road_seg_idx:05d}">\n'
+                        f'      <static>true</static>\n'
+                        f'      <pose>{mx:.2f} {my:.2f} '
+                        f'{_ROAD_HEIGHT / 2 + _ROAD_Z:.2f} '
+                        f'0 0 {yaw:.4f}</pose>\n'
+                        f'      <link name="link">\n'
+                        f'        <visual name="visual">\n'
+                        f'          <geometry>\n'
+                        f'            <box>\n'
+                        f'              <size>{dash_len:.2f} {width} '
+                        f'{_ROAD_HEIGHT:.1f}</size>\n'
+                        f'            </box>\n'
+                        f'          </geometry>\n'
+                        f'          <material>\n'
+                        f'            <ambient>{_ROAD_AMB}</ambient>\n'
+                        f'            <diffuse>{_ROAD_DIF}</diffuse>\n'
+                        f'          </material>\n'
+                        f'        </visual>\n'
+                        f'      </link>\n'
+                        f'    </model>'
+                    )
+                    road_seg_idx += 1
 
     # Build grouped container models
     s57_types = {

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/feature_models.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/feature_models.py
@@ -894,7 +894,7 @@ def generate_feature_models(
     terrain=None, terrain_bounds=None, debug=False,
     skip_categories=None, simplify_tolerance=0.0,
     max_wall_segments=None,
-    osm_man_made=None, osm_roads=None,
+    osm_man_made=None,
 ):
     """Convert S57 features to grouped SDF <model> XML strings.
 
@@ -1218,83 +1218,6 @@ def generate_feature_models(
             if wall:
                 marine_models.append(wall)
 
-    # Roads from OSM (dashed debug markers floating above terrain)
-    _ROAD_WIDTHS = {
-        'motorway': 12.0, 'trunk': 10.0, 'primary': 9.0,
-        'secondary': 8.0, 'tertiary': 7.0, 'residential': 6.0,
-        'unclassified': 5.0, 'service': 4.0, 'track': 3.0,
-        'footway': 1.5, 'path': 1.5, 'cycleway': 2.0, 'steps': 1.5,
-    }
-    _ROAD_AMB = '0.6 0.5 0.2 1.0'
-    _ROAD_DIF = '0.8 0.7 0.3 1.0'
-    _ROAD_DASH_LEN = 5.0    # meters per dash segment
-    _ROAD_DASH_GAP = 50.0   # meters between dash starts
-    _ROAD_HEIGHT = 0.15     # dash thickness
-    _ROAD_Z = 5.0           # float above terrain for debug visibility
-    road_models = []
-    road_seg_idx = 0
-    for i, road in enumerate(osm_roads or []):
-        width = _ROAD_WIDTHS.get(road.highway, 4.0)
-        geom_type = road.geometry.GetGeometryType() & 0xFF
-        lines = []
-        if geom_type == 2:
-            lines = [road.geometry]
-        elif geom_type == 5:
-            lines = [road.geometry.GetGeometryRef(j)
-                     for j in range(road.geometry.GetGeometryCount())]
-        for line in lines:
-            # Walk along the linestring, placing dashes at intervals
-            n = line.GetPointCount()
-            if n < 2:
-                continue
-            # Build ENU points for the line
-            pts = []
-            for pi in range(n):
-                lon, lat = line.GetX(pi), line.GetY(pi)
-                x, y = _latlon_to_enu(lat, lon, center_lat, center_lon)
-                pts.append((x, y))
-            # Walk along cumulative distance, emit dashes
-            dist_since_dash = 0.0
-            for pi in range(len(pts) - 1):
-                x0, y0 = pts[pi]
-                x1, y1 = pts[pi + 1]
-                dx, dy = x1 - x0, y1 - y0
-                seg_len = math.sqrt(dx * dx + dy * dy)
-                if seg_len < 0.1:
-                    continue
-                dist_since_dash += seg_len
-                if dist_since_dash >= _ROAD_DASH_GAP:
-                    dist_since_dash = 0.0
-                    mx = (x0 + x1) / 2.0
-                    my = (y0 + y1) / 2.0
-                    mz = _sample_terrain_elevation(
-                        mx, my, terrain, terrain_bounds)
-                    yaw = math.atan2(dy, dx)
-                    dash_len = min(_ROAD_DASH_LEN, seg_len)
-                    road_models.append(
-                        f'    <model name="road_{road_seg_idx:05d}">\n'
-                        f'      <static>true</static>\n'
-                        f'      <pose>{mx:.2f} {my:.2f} '
-                        f'{mz + _ROAD_HEIGHT / 2 + _ROAD_Z:.2f} '
-                        f'0 0 {yaw:.4f}</pose>\n'
-                        f'      <link name="link">\n'
-                        f'        <visual name="visual">\n'
-                        f'          <geometry>\n'
-                        f'            <box>\n'
-                        f'              <size>{dash_len:.2f} {width} '
-                        f'{_ROAD_HEIGHT:.1f}</size>\n'
-                        f'            </box>\n'
-                        f'          </geometry>\n'
-                        f'          <material>\n'
-                        f'            <ambient>{_ROAD_AMB}</ambient>\n'
-                        f'            <diffuse>{_ROAD_DIF}</diffuse>\n'
-                        f'          </material>\n'
-                        f'        </visual>\n'
-                        f'      </link>\n'
-                        f'    </model>'
-                    )
-                    road_seg_idx += 1
-
     # Build grouped container models
     s57_types = {
         'buildings': s57_buildings,
@@ -1313,7 +1236,6 @@ def generate_feature_models(
     osm_types = {
         'buildings': osm_buildings,
         'marine': marine_models,
-        'roads': road_models,
     }
 
     return {

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/feature_models.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/feature_models.py
@@ -20,7 +20,7 @@ import re
 
 from osgeo import ogr
 
-from .coordinates import latlon_to_enu
+from .coordinates import enu_to_latlon, latlon_to_enu
 
 # Default extrusion heights by OBJL code
 _BUILDING_HEIGHTS = {
@@ -1246,12 +1246,8 @@ def _scatter_trees(natural_list, center_lat, center_lon, terrain,
                 jn = n + rng.uniform(-jitter, jitter)
 
                 # Convert back to lat/lon for point-in-polygon test
-                # Approximate inverse: use linear scaling from center
-                lat_per_m = 1.0 / 111320.0
-                lon_per_m = 1.0 / (111320.0 * math.cos(
-                    math.radians(center_lat)))
-                pt_lat = center_lat + jn * lat_per_m
-                pt_lon = center_lon + je * lon_per_m
+                pt_lat, pt_lon = enu_to_latlon(
+                    je, jn, center_lat, center_lon)
 
                 pt = ogr.Geometry(ogr.wkbPoint)
                 pt.AddPoint(pt_lon, pt_lat)

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/feature_models.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/feature_models.py
@@ -1093,20 +1093,6 @@ def generate_feature_models(
             continue
         params = _SLCONS_PARAMS.get(sc.catslc, _SLCONS_DEFAULT)
         height, wall_width, amb, dif = params
-        # Enriched pier: use OSM polygon instead of S57 linestring
-        if sc.osm_geometry is not None:
-            centroid = sc.osm_geometry.Centroid()
-            cx, cy = _latlon_to_enu(
-                centroid.GetY(), centroid.GetX(), center_lat, center_lon)
-            z = _sample_terrain_elevation(cx, cy, terrain, terrain_bounds)
-            model = _polygon_to_polyline_model(
-                f'slcons_{i:04d}', sc.osm_geometry,
-                center_lat, center_lon, 0.5, z=z,
-                ambient=amb, diffuse=dif, collision=_LAND,
-            )
-            if model:
-                shore_constructions.append(model)
-            continue
         geom_type = sc.geometry.GetGeometryType() & 0xFF
         if geom_type in (2, 5, 7):  # LineString, MultiLineString, Collection
             wall, n_segs = _slcons_wall_model(
@@ -1121,9 +1107,13 @@ def generate_feature_models(
             if wall_seg_remaining is not None:
                 wall_seg_remaining -= n_segs
         elif geom_type in (3, 6):  # Polygon, MultiPolygon
+            centroid = sc.geometry.Centroid()
+            cx, cy = _latlon_to_enu(
+                centroid.GetY(), centroid.GetX(), center_lat, center_lon)
+            z = _sample_terrain_elevation(cx, cy, terrain, terrain_bounds)
             model = _polygon_to_polyline_model(
                 f'slcons_{i:04d}', sc.geometry,
-                center_lat, center_lon, height, z=0.0,
+                center_lat, center_lon, height, z=z,
                 ambient=amb, diffuse=dif, collision=_LAND,
             )
             if model:

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/feature_models.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/feature_models.py
@@ -1719,10 +1719,19 @@ def generate_feature_models(
             if mm.floating is not True:
                 continue
             mm_geom = mm.geometry
-            # Check distance from gangway endpoints to floating feature
-            for pt_idx in range(mm_geom.GetPointCount()):
-                fx, fy = _latlon_to_enu(mm_geom.GetY(pt_idx),
-                                        mm_geom.GetX(pt_idx),
+            # Check distance from gangway endpoints to floating feature.
+            # Polygon geometries return 0 for GetPointCount() — iterate
+            # the exterior ring instead.
+            geom_type = mm_geom.GetGeometryType() & 0xFF
+            if geom_type == 3:  # Polygon
+                point_source = mm_geom.GetGeometryRef(0)
+                if point_source is None:
+                    continue
+            else:
+                point_source = mm_geom
+            for pt_idx in range(point_source.GetPointCount()):
+                fx, fy = _latlon_to_enu(point_source.GetY(pt_idx),
+                                        point_source.GetX(pt_idx),
                                         center_lat, center_lon)
                 ds = math.sqrt((start_enu[0] - fx) ** 2
                                + (start_enu[1] - fy) ** 2)

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/feature_models.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/feature_models.py
@@ -512,12 +512,213 @@ _CATSLC_SKIP_NAME = {
 }
 
 
+def _simplify_enu_linestring(enu_pts, min_seg_len, min_angle_deg=5.0):
+    """Remove nearly-collinear vertices and segments shorter than min_seg_len.
+
+    This prevents the offset polygon from self-intersecting at very
+    short segments or near-180° bends.
+    """
+    if len(enu_pts) <= 2:
+        return list(enu_pts)
+
+    min_cos = math.cos(math.radians(min_angle_deg))
+    result = [enu_pts[0]]
+
+    for i in range(1, len(enu_pts) - 1):
+        px, py = result[-1]
+        cx, cy = enu_pts[i]
+        nx, ny = enu_pts[i + 1]
+
+        dx0, dy0 = cx - px, cy - py
+        dx1, dy1 = nx - cx, ny - cy
+        l0 = math.sqrt(dx0 * dx0 + dy0 * dy0)
+        l1 = math.sqrt(dx1 * dx1 + dy1 * dy1)
+
+        # Skip point if incoming segment is too short
+        if l0 < min_seg_len:
+            continue
+
+        # Skip nearly collinear points (angle between segments < threshold)
+        if l0 > 1e-9 and l1 > 1e-9:
+            dot = (dx0 * dx1 + dy0 * dy1) / (l0 * l1)
+            if dot > min_cos:
+                continue
+
+        result.append(enu_pts[i])
+
+    result.append(enu_pts[-1])
+
+    # Remove final short trailing segment
+    if len(result) > 2:
+        dx = result[-1][0] - result[-2][0]
+        dy = result[-1][1] - result[-2][1]
+        if math.sqrt(dx * dx + dy * dy) < min_seg_len:
+            result[-2] = result[-1]
+            result.pop()
+
+    return result
+
+
+def _offset_open(pts, hw, max_miter):
+    """Offset an open linestring into a polygon (right fwd + left back)."""
+    n = len(pts)
+    if n < 2:
+        return []
+    normals = []
+    for i in range(n - 1):
+        dx = pts[i + 1][0] - pts[i][0]
+        dy = pts[i + 1][1] - pts[i][1]
+        sl = math.sqrt(dx * dx + dy * dy)
+        if sl < 1e-9:
+            normals.append((0.0, 0.0))
+        else:
+            normals.append((dy / sl, -dx / sl))
+
+    def _miter(pt, nb, na):
+        mx = nb[0] + na[0]
+        my = nb[1] + na[1]
+        mlen = math.sqrt(mx * mx + my * my)
+        if mlen < 1e-9:
+            mx, my = nb
+            scale = hw
+        else:
+            mx /= mlen
+            my /= mlen
+            dot = mx * nb[0] + my * nb[1]
+            scale = min(hw / dot, max_miter) if abs(dot) > 0.01 else max_miter
+        return ((pt[0] + mx * scale, pt[1] + my * scale),
+                (pt[0] - mx * scale, pt[1] - my * scale))
+
+    right, left = [], []
+    for i in range(n):
+        if i == 0:
+            nx, ny = normals[0]
+            right.append((pts[0][0] + nx * hw, pts[0][1] + ny * hw))
+            left.append((pts[0][0] - nx * hw, pts[0][1] - ny * hw))
+        elif i == n - 1:
+            nx, ny = normals[-1]
+            right.append((pts[i][0] + nx * hw, pts[i][1] + ny * hw))
+            left.append((pts[i][0] - nx * hw, pts[i][1] - ny * hw))
+        else:
+            r, l = _miter(pts[i], normals[i - 1], normals[i])
+            right.append(r)
+            left.append(l)
+    return right + list(reversed(left))
+
+
+def _offset_linestring_to_polygon(enu_pts, half_width):
+    """Offset a linestring by half_width on each side to create a polygon.
+
+    Uses miter joins at internal vertices for square corners.  At very
+    acute angles (< 30°) the miter is clamped to 3× half_width to avoid
+    extreme spikes.  Input is simplified first to remove segments shorter
+    than the wall width that would cause self-intersection.
+
+    Returns list of (x, y) tuples forming a closed polygon (right side
+    forward, then left side backward, forming a loop).
+    """
+    # Simplify to avoid self-intersection from short segments
+    enu_pts = _simplify_enu_linestring(enu_pts, half_width * 2.0)
+
+    # Detect closed linestring (first == last point)
+    is_closed = (len(enu_pts) >= 4
+                 and abs(enu_pts[0][0] - enu_pts[-1][0]) < 0.01
+                 and abs(enu_pts[0][1] - enu_pts[-1][1]) < 0.01)
+    if is_closed:
+        enu_pts = enu_pts[:-1]  # remove duplicate closing point
+
+    n = len(enu_pts)
+    if n < 2:
+        return []
+
+    hw = half_width
+    max_miter = 3.0 * hw  # clamp for very acute angles
+
+    # Compute unit normals (perpendicular, pointing right) per segment
+    n_segs = n if is_closed else n - 1
+    normals = []
+    for i in range(n_segs):
+        j = (i + 1) % n
+        dx = enu_pts[j][0] - enu_pts[i][0]
+        dy = enu_pts[j][1] - enu_pts[i][1]
+        seg_len = math.sqrt(dx * dx + dy * dy)
+        if seg_len < 1e-9:
+            normals.append((0.0, 0.0))
+        else:
+            # Right-hand normal: rotate direction 90° clockwise
+            normals.append((dy / seg_len, -dx / seg_len))
+
+    def _miter_offset(pt, norm_before, norm_after):
+        """Compute right and left offset points at a mitered vertex."""
+        mx = norm_before[0] + norm_after[0]
+        my = norm_before[1] + norm_after[1]
+        mlen = math.sqrt(mx * mx + my * my)
+        if mlen < 1e-9:
+            mx, my = norm_before
+            scale = hw
+        else:
+            mx /= mlen
+            my /= mlen
+            dot = mx * norm_before[0] + my * norm_before[1]
+            if abs(dot) < 0.01:
+                scale = max_miter
+            else:
+                scale = min(hw / dot, max_miter)
+        return ((pt[0] + mx * scale, pt[1] + my * scale),
+                (pt[0] - mx * scale, pt[1] - my * scale))
+
+    # Compute offset points at each vertex using miter joins
+    right_pts = []
+    left_pts = []
+
+    for i in range(n):
+        if is_closed:
+            # All vertices are internal — wrap around
+            nb = normals[(i - 1) % n_segs]
+            na = normals[i % n_segs]
+            r, l = _miter_offset(enu_pts[i], nb, na)
+        elif i == 0:
+            # Start cap: use first segment's normal
+            nx, ny = normals[0]
+            r = (enu_pts[i][0] + nx * hw, enu_pts[i][1] + ny * hw)
+            l = (enu_pts[i][0] - nx * hw, enu_pts[i][1] - ny * hw)
+        elif i == n - 1:
+            # End cap: use last segment's normal
+            nx, ny = normals[-1]
+            r = (enu_pts[i][0] + nx * hw, enu_pts[i][1] + ny * hw)
+            l = (enu_pts[i][0] - nx * hw, enu_pts[i][1] - ny * hw)
+        else:
+            # Internal vertex: miter join
+            r, l = _miter_offset(enu_pts[i], normals[i - 1], normals[i])
+        right_pts.append(r)
+        left_pts.append(l)
+
+    if is_closed:
+        # Closed linestring: split at midpoint into two open segments,
+        # each offset independently.  This avoids the figure-8 self-
+        # intersection that arises from concatenating right+left loops.
+        mid = n // 2
+        seg1 = enu_pts[:mid + 1]  # first half (overlaps at midpoint)
+        seg2 = enu_pts[mid:] + [enu_pts[0]]  # second half, close back
+        poly1 = _offset_open(seg1, hw, max_miter)
+        poly2 = _offset_open(seg2, hw, max_miter)
+        return ('split', poly1, poly2)
+
+    # Open linestring: right side forward, left side backward
+    return right_pts + list(reversed(left_pts))
+
+
 def _slcons_wall_model(name, geometry, center_lat, center_lon,
                         height=2.0, wall_width=1.0, z=0.0,
                         ambient='0.55 0.55 0.50 1.0',
                         diffuse='0.65 0.65 0.60 1.0',
                         collision=True, seg_budget=None):
-    """Generate SDF wall segments along a shoreline construction linestring."""
+    """Generate SDF polyline extrusion along a shoreline construction.
+
+    Offsets the linestring by wall_width/2 on each side to create a
+    polygon with mitered corners, then extrudes it as a single polyline
+    model.  This produces clean square joints at all bend angles.
+    """
     geom_type = geometry.GetGeometryType() & 0xFF
     if geom_type == 2:  # wkbLineString
         lines = [geometry]
@@ -532,12 +733,12 @@ def _slcons_wall_model(name, geometry, center_lat, center_lon,
             if stype in (2, 5):  # LineString or MultiLineString
                 lines.append(sub)
     else:
-        return ''
+        return '', 0
 
-    segments = []
-    seg_idx = 0
+    models = []
+    model_idx = 0
     for line in lines:
-        if seg_budget is not None and seg_idx >= seg_budget:
+        if seg_budget is not None and model_idx >= seg_budget:
             break
         # Handle MultiLineString sub-geometries
         if (line.GetGeometryType() & 0xFF) == 5:
@@ -546,58 +747,125 @@ def _slcons_wall_model(name, geometry, center_lat, center_lon,
         else:
             sub_lines = [line]
         for sline in sub_lines:
-            if seg_budget is not None and seg_idx >= seg_budget:
+            if seg_budget is not None and model_idx >= seg_budget:
                 break
             n = sline.GetPointCount()
-            for i in range(n - 1):
-                if seg_budget is not None and seg_idx >= seg_budget:
-                    break
-                lon0, lat0 = sline.GetX(i), sline.GetY(i)
-                lon1, lat1 = sline.GetX(i + 1), sline.GetY(i + 1)
-                x0, y0 = _latlon_to_enu(lat0, lon0, center_lat, center_lon)
-                x1, y1 = _latlon_to_enu(lat1, lon1, center_lat, center_lon)
-                mx = (x0 + x1) / 2.0
-                my = (y0 + y1) / 2.0
-                dx, dy = x1 - x0, y1 - y0
-                length = math.sqrt(dx * dx + dy * dy)
-                if length < 0.1:
-                    continue
-                yaw = math.atan2(dy, dx)
-                segments.append(
-                    f'    <model name="{name}_seg{seg_idx:04d}">\n'
-                    f'      <static>true</static>\n'
-                    f'      <pose>{mx:.2f} {my:.2f} {height / 2 + z:.2f} '
-                    f'0 0 {yaw:.4f}</pose>\n'
-                    f'      <link name="link">\n'
-                    f'        <visual name="visual">\n'
-                    f'          <geometry>\n'
-                    f'            <box>\n'
-                    f'              <size>{length:.2f} {wall_width} '
-                    f'{height:.1f}</size>\n'
-                    f'            </box>\n'
-                    f'          </geometry>\n'
-                    f'          <material>\n'
-                    f'            <ambient>{ambient}</ambient>\n'
-                    f'            <diffuse>{diffuse}</diffuse>\n'
-                    f'          </material>\n'
-                    f'        </visual>\n'
-                    + (
-                        f'        <collision name="collision">\n'
-                        f'          <geometry>\n'
-                        f'            <box>\n'
-                        f'              <size>{length:.2f} {wall_width} '
-                        f'{height:.1f}</size>\n'
-                        f'            </box>\n'
-                        f'          </geometry>\n'
-                        f'        </collision>\n'
-                        if collision else ''
-                    )
-                    + f'      </link>\n'
-                    f'    </model>'
-                )
-                seg_idx += 1
+            if n < 2:
+                continue
 
-    return '\n\n'.join(segments), seg_idx
+            # Convert to ENU
+            enu_pts = []
+            for pi in range(n):
+                lon_p, lat_p = sline.GetX(pi), sline.GetY(pi)
+                enu_pts.append(
+                    _latlon_to_enu(lat_p, lon_p, center_lat, center_lon))
+
+            # Offset linestring to polygon
+            result = _offset_linestring_to_polygon(
+                enu_pts, wall_width / 2.0)
+
+            # Handle closed linestrings (split into two open segments)
+            if isinstance(result, tuple) and result[0] == 'split':
+                _, poly1, poly2 = result
+                # Emit each half as a separate model
+                for split_pts in (poly1, poly2):
+                    if len(split_pts) < 3:
+                        continue
+                    scx = sum(p[0] for p in split_pts) / len(split_pts)
+                    scy = sum(p[1] for p in split_pts) / len(split_pts)
+                    pts_lines = []
+                    for px, py in split_pts:
+                        pts_lines.append(
+                            f'          <point>{px - scx:.2f}'
+                            f' {py - scy:.2f}</point>')
+                    pts_lines.append(
+                        f'          <point>{split_pts[0][0] - scx:.2f}'
+                        f' {split_pts[0][1] - scy:.2f}</point>')
+                    ps = '\n'.join(pts_lines)
+                    pl_sdf = (
+                        f'            <polyline>\n'
+                        f'              <height>{height:.1f}</height>\n'
+                        f'{ps}\n'
+                        f'            </polyline>')
+                    m = (
+                        f'    <model name="{name}_p{model_idx:04d}">\n'
+                        f'      <static>true</static>\n'
+                        f'      <pose>{scx:.2f} {scy:.2f} {z:.2f}'
+                        f' 0 0 0</pose>\n'
+                        f'      <link name="link">\n'
+                        f'        <visual name="visual">\n'
+                        f'          <geometry>\n'
+                        f'{pl_sdf}\n'
+                        f'          </geometry>\n'
+                        f'          <material>\n'
+                        f'            <ambient>{ambient}</ambient>\n'
+                        f'            <diffuse>{diffuse}</diffuse>\n'
+                        f'          </material>\n'
+                        f'        </visual>\n'
+                        + (
+                            f'        <collision name="collision">\n'
+                            f'          <geometry>\n'
+                            f'{pl_sdf}\n'
+                            f'          </geometry>\n'
+                            f'        </collision>\n'
+                            if collision else ''
+                        )
+                        + f'      </link>\n'
+                        f'    </model>'
+                    )
+                    models.append(m)
+                    model_idx += 1
+                continue
+
+            poly_pts = result
+            if len(poly_pts) < 3:
+                continue
+            cx = sum(p[0] for p in poly_pts) / len(poly_pts)
+            cy = sum(p[1] for p in poly_pts) / len(poly_pts)
+
+            points = []
+            for px, py in poly_pts:
+                points.append(
+                    f'          <point>{px - cx:.2f}'
+                    f' {py - cy:.2f}</point>')
+            points.append(
+                f'          <point>{poly_pts[0][0] - cx:.2f}'
+                f' {poly_pts[0][1] - cy:.2f}</point>')
+            polyline_sdf = (
+                f'            <polyline>\n'
+                f'              <height>{height:.1f}</height>\n'
+                + '\n'.join(points) + '\n'
+                f'            </polyline>')
+
+            model = (
+                f'    <model name="{name}_p{model_idx:04d}">\n'
+                f'      <static>true</static>\n'
+                f'      <pose>{cx:.2f} {cy:.2f} {z:.2f} 0 0 0</pose>\n'
+                f'      <link name="link">\n'
+                f'        <visual name="visual">\n'
+                f'          <geometry>\n'
+                f'{polyline_sdf}\n'
+                f'          </geometry>\n'
+                f'          <material>\n'
+                f'            <ambient>{ambient}</ambient>\n'
+                f'            <diffuse>{diffuse}</diffuse>\n'
+                f'          </material>\n'
+                f'        </visual>\n'
+                + (
+                    f'        <collision name="collision">\n'
+                    f'          <geometry>\n'
+                    f'{polyline_sdf}\n'
+                    f'          </geometry>\n'
+                    f'        </collision>\n'
+                    if collision else ''
+                )
+                + f'      </link>\n'
+                f'    </model>'
+            )
+            models.append(model)
+            model_idx += 1
+
+    return '\n\n'.join(models), model_idx
 
 
 def _slcons_point_model(name, x, y, z=0.0, collision=True):
@@ -895,6 +1163,7 @@ def generate_feature_models(
     skip_categories=None, simplify_tolerance=0.0,
     max_wall_segments=None,
     osm_man_made=None,
+    osm_bridge_roads=None,
 ):
     """Convert S57 features to grouped SDF <model> XML strings.
 
@@ -1093,12 +1362,32 @@ def generate_feature_models(
             continue
         params = _SLCONS_PARAMS.get(sc.catslc, _SLCONS_DEFAULT)
         height, wall_width, amb, dif = params
+
+        # Adjust rendering based on water level attribute (all SLCONS types)
+        # watlev: 2=always dry, 3=submerged, 4=covers/uncovers (tidal),
+        #         7=floating
+        if sc.watlev == 7:
+            # Floating — slab straddling water surface
+            height = 1.0
+            z_override = -0.5
+        elif sc.watlev == 4:
+            # Tidal / covers and uncovers — slab at water surface
+            height = 1.0
+            z_override = -0.5
+        elif sc.watlev == 3:
+            # Submerged — thin slab below water
+            height = 0.5
+            z_override = -1.0
+        else:
+            z_override = None
+
         geom_type = sc.geometry.GetGeometryType() & 0xFF
         if geom_type in (2, 5, 7):  # LineString, MultiLineString, Collection
+            z = z_override if z_override is not None else 0.0
             wall, n_segs = _slcons_wall_model(
                 f'slcons_{i:04d}', sc.geometry,
                 center_lat, center_lon,
-                height=height, wall_width=wall_width,
+                height=height, wall_width=wall_width, z=z,
                 ambient=amb, diffuse=dif, collision=_LAND,
                 seg_budget=wall_seg_remaining,
             )
@@ -1107,10 +1396,13 @@ def generate_feature_models(
             if wall_seg_remaining is not None:
                 wall_seg_remaining -= n_segs
         elif geom_type in (3, 6):  # Polygon, MultiPolygon
-            centroid = sc.geometry.Centroid()
-            cx, cy = _latlon_to_enu(
-                centroid.GetY(), centroid.GetX(), center_lat, center_lon)
-            z = _sample_terrain_elevation(cx, cy, terrain, terrain_bounds)
+            if z_override is not None:
+                z = z_override
+            else:
+                centroid = sc.geometry.Centroid()
+                cx, cy = _latlon_to_enu(
+                    centroid.GetY(), centroid.GetX(), center_lat, center_lon)
+                z = _sample_terrain_elevation(cx, cy, terrain, terrain_bounds)
             model = _polygon_to_polyline_model(
                 f'slcons_{i:04d}', sc.geometry,
                 center_lat, center_lon, height, z=z,
@@ -1194,33 +1486,150 @@ def generate_feature_models(
         'groyne': ('0.45 0.45 0.43 1.0', '0.55 0.55 0.53 1.0'),
     }
     _MARINE_DEFAULT_COLOR = ('0.55 0.55 0.53 1.0', '0.65 0.65 0.63 1.0')
+    # Floating pier dimensions: deck freeboard and total slab thickness
+    _FLOATING_FREEBOARD = 0.5   # deck height above water (meters)
+    _FLOATING_DRAFT = 0.5       # depth below water (meters)
+    _FLOATING_THICKNESS = _FLOATING_FREEBOARD + _FLOATING_DRAFT  # total slab
     marine_models = []
     for i, mm in enumerate(osm_man_made or []):
         amb, dif = _MARINE_COLORS.get(mm.man_made, _MARINE_DEFAULT_COLOR)
+        is_floating = mm.floating is True
         geom_type = mm.geometry.GetGeometryType() & 0xFF
         if geom_type in (3, 6):  # Polygon — flat extruded slab
-            centroid = mm.geometry.Centroid()
-            cx, cy = _latlon_to_enu(
-                centroid.GetY(), centroid.GetX(), center_lat, center_lon)
-            z = _sample_terrain_elevation(cx, cy, terrain, terrain_bounds)
+            if is_floating:
+                z = -_FLOATING_DRAFT
+                slab_height = _FLOATING_THICKNESS
+            else:
+                centroid = mm.geometry.Centroid()
+                cx, cy = _latlon_to_enu(
+                    centroid.GetY(), centroid.GetX(), center_lat, center_lon)
+                z = _sample_terrain_elevation(cx, cy, terrain, terrain_bounds)
+                slab_height = 1.0
             model = _polygon_to_polyline_model(
                 f'marine_{i:04d}_{mm.man_made}', mm.geometry,
-                center_lat, center_lon, 1.0, z=z,
+                center_lat, center_lon, slab_height, z=z,
                 ambient=amb, diffuse=dif, collision=False,
             )
             if model:
                 marine_models.append(model)
         elif geom_type in (2, 5, 7):  # LineString — wall segments
-            wall_width = 3.0 if mm.man_made in ('breakwater', 'groyne') else 2.0
-            height = 2.0 if mm.man_made in ('breakwater', 'groyne') else 1.0
+            if is_floating:
+                wall_width = 3.0
+                height = _FLOATING_THICKNESS
+                z = -_FLOATING_DRAFT
+            else:
+                wall_width = 3.0 if mm.man_made in ('breakwater', 'groyne') else 2.0
+                height = 2.0 if mm.man_made in ('breakwater', 'groyne') else 1.0
+                z = 0.0
             wall, _ = _slcons_wall_model(
                 f'marine_{i:04d}_{mm.man_made}', mm.geometry,
                 center_lat, center_lon,
-                height=height, wall_width=wall_width,
+                height=height, wall_width=wall_width, z=z,
                 ambient=amb, diffuse=dif, collision=False,
             )
             if wall:
                 marine_models.append(wall)
+
+    # OSM bridge roads (gangways, elevated walkways)
+    # Gangway: sloped ramp from fixed pier (higher) to floating pier (lower).
+    # We detect which end connects to a floating pier to determine slope.
+    _GANGWAY_FIXED_Z = 1.5   # fixed end height above water (meters)
+    _GANGWAY_FLOAT_Z = 0.5   # floating end height (matches freeboard)
+    _GANGWAY_THICKNESS = 0.3
+    osm_bridge_models = []
+    for i, road in enumerate(osm_bridge_roads or []):
+        geom = road.geometry
+        n = geom.GetPointCount()
+        if n < 2:
+            continue
+
+        # Convert endpoints to ENU
+        start_enu = _latlon_to_enu(geom.GetY(0), geom.GetX(0),
+                                   center_lat, center_lon)
+        end_enu = _latlon_to_enu(geom.GetY(n - 1), geom.GetX(n - 1),
+                                 center_lat, center_lon)
+
+        # Determine which end is higher (fixed pier) vs lower (floating pier)
+        # by checking proximity to floating vs fixed man_made features.
+        start_near_float = False
+        end_near_float = False
+        for mm in (osm_man_made or []):
+            if mm.floating is not True:
+                continue
+            mm_geom = mm.geometry
+            # Check distance from gangway endpoints to floating feature
+            for pt_idx in range(mm_geom.GetPointCount()):
+                fx, fy = _latlon_to_enu(mm_geom.GetY(pt_idx),
+                                        mm_geom.GetX(pt_idx),
+                                        center_lat, center_lon)
+                ds = math.sqrt((start_enu[0] - fx) ** 2
+                               + (start_enu[1] - fy) ** 2)
+                de = math.sqrt((end_enu[0] - fx) ** 2
+                               + (end_enu[1] - fy) ** 2)
+                if ds < 5.0:
+                    start_near_float = True
+                if de < 5.0:
+                    end_near_float = True
+
+        if start_near_float and not end_near_float:
+            z_start = _GANGWAY_FLOAT_Z
+            z_end = _GANGWAY_FIXED_Z
+        elif end_near_float and not start_near_float:
+            z_start = _GANGWAY_FIXED_Z
+            z_end = _GANGWAY_FLOAT_Z
+        else:
+            # Can't determine — use fixed height
+            z_start = _GANGWAY_FIXED_Z
+            z_end = _GANGWAY_FIXED_Z
+
+        # Build as individual box segments with linearly interpolated z
+        width = 2.0 if road.highway == 'footway' else 3.5
+        amb = '0.55 0.50 0.45 1.0'
+        dif = '0.65 0.60 0.55 1.0'
+        seg_models = []
+        for si in range(n - 1):
+            t0 = si / (n - 1)
+            t1 = (si + 1) / (n - 1)
+            z0 = z_start + (z_end - z_start) * t0
+            z1 = z_start + (z_end - z_start) * t1
+            e0 = _latlon_to_enu(geom.GetY(si), geom.GetX(si),
+                                center_lat, center_lon)
+            e1 = _latlon_to_enu(geom.GetY(si + 1), geom.GetX(si + 1),
+                                center_lat, center_lon)
+            cx = (e0[0] + e1[0]) / 2.0
+            cy = (e0[1] + e1[1]) / 2.0
+            cz = (z0 + z1) / 2.0
+            dx = e1[0] - e0[0]
+            dy = e1[1] - e0[1]
+            seg_len = math.sqrt(dx * dx + dy * dy)
+            if seg_len < 0.1:
+                continue
+            yaw = math.atan2(dy, dx)
+            dz = z1 - z0
+            pitch = -math.atan2(dz, seg_len)
+            seg_models.append(
+                f'    <model name="osm_bridge_{i:04d}_s{si:02d}">\n'
+                f'      <static>true</static>\n'
+                f'      <pose>{cx:.2f} {cy:.2f} {cz:.2f}'
+                f' 0 {pitch:.4f} {yaw:.4f}</pose>\n'
+                f'      <link name="link">\n'
+                f'        <visual name="visual">\n'
+                f'          <geometry>\n'
+                f'            <box>\n'
+                f'              <size>{seg_len:.2f} {width:.1f}'
+                f' {_GANGWAY_THICKNESS}</size>\n'
+                f'            </box>\n'
+                f'          </geometry>\n'
+                f'          <material>\n'
+                f'            <ambient>{amb}</ambient>\n'
+                f'            <diffuse>{dif}</diffuse>\n'
+                f'          </material>\n'
+                f'        </visual>\n'
+                f'      </link>\n'
+                f'    </model>'
+            )
+        if seg_models:
+            osm_bridge_models.extend(seg_models)
 
     # Build grouped container models
     s57_types = {
@@ -1240,6 +1649,7 @@ def generate_feature_models(
     osm_types = {
         'buildings': osm_buildings,
         'marine': marine_models,
+        'bridges': osm_bridge_models,
     }
 
     return {

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/feature_models.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/feature_models.py
@@ -15,7 +15,10 @@
 """Convert S57 features to parametric SDF model elements for Gazebo."""
 
 import math
+import random
 import re
+
+from osgeo import ogr
 
 from .coordinates import latlon_to_enu
 
@@ -1157,6 +1160,163 @@ def _wrap_group(group_name, model_lists):
     )
 
 
+# Tree generation constants
+_TREE_SPACING_DEFAULT = 8.0  # meters between grid points at natural density
+_TREE_MAX_COUNT = 500        # default cap on total tree count
+_TRUNK_RADIUS = 0.15
+_TRUNK_HEIGHT = 3.0
+_CANOPY_RADIUS = 2.5
+_CANOPY_HEIGHT = 5.0
+_TREE_HEIGHT_VARIANCE = 0.3  # +/- fraction of nominal height
+
+
+def _compute_tree_spacing(natural_list, center_lat, center_lon, max_trees):
+    """Compute grid spacing so total trees stays under max_trees.
+
+    Estimates total wood area in m² using ENU-projected bounding boxes,
+    then widens spacing if the default would exceed the cap.
+    """
+    total_area = 0.0
+    for nat in natural_list:
+        if nat.natural != 'wood':
+            continue
+        geom = nat.geometry
+        if geom is None or geom.IsEmpty():
+            continue
+        # Use bounding box area as upper estimate (simple + reliable)
+        env = geom.GetEnvelope()  # (minX, maxX, minY, maxY)
+        sw = _latlon_to_enu(env[2], env[0], center_lat, center_lon)
+        ne = _latlon_to_enu(env[3], env[1], center_lat, center_lon)
+        bbox_area = abs(ne[0] - sw[0]) * abs(ne[1] - sw[1])
+        # Polygons typically fill ~50-70% of their bbox
+        total_area += bbox_area * 0.5
+
+    if total_area == 0:
+        return _TREE_SPACING_DEFAULT
+
+    # At default spacing, roughly one tree per spacing^2 of polygon area
+    trees_at_default = total_area / (_TREE_SPACING_DEFAULT ** 2)
+    if trees_at_default <= max_trees:
+        return _TREE_SPACING_DEFAULT
+
+    # Widen spacing: trees ~ area / spacing^2
+    spacing = math.sqrt(total_area / max_trees)
+    return spacing
+
+
+def _scatter_trees(natural_list, center_lat, center_lon, terrain,
+                   terrain_bounds, max_trees=_TREE_MAX_COUNT):
+    """Generate SDF tree models scattered within natural=wood polygons.
+
+    Uses a grid-based approach with jitter for natural-looking placement.
+    Spacing is adjusted so total count stays under max_trees.
+    Each tree is a cylinder trunk + cone canopy using SDF primitives.
+    """
+    spacing = _compute_tree_spacing(
+        natural_list, center_lat, center_lon, max_trees)
+    jitter = spacing * 0.375  # scale jitter with spacing
+
+    tree_models = []
+    tree_idx = 0
+    rng = random.Random(42)  # deterministic for reproducible worlds
+
+    for nat in natural_list:
+        if nat.natural != 'wood':
+            continue
+
+        geom = nat.geometry
+        if geom is None or geom.IsEmpty():
+            continue
+
+        # Get polygon bounding box in lat/lon
+        env = geom.GetEnvelope()  # (minX, maxX, minY, maxY)
+        min_lon, max_lon, min_lat, max_lat = env
+
+        # Convert bbox corners to ENU to determine grid extent
+        sw = _latlon_to_enu(min_lat, min_lon, center_lat, center_lon)
+        ne = _latlon_to_enu(max_lat, max_lon, center_lat, center_lon)
+
+        # Grid over the ENU bounding box
+        e = sw[0]
+        while e < ne[0] and tree_idx < max_trees:
+            n = sw[1]
+            while n < ne[1] and tree_idx < max_trees:
+                # Add jitter
+                je = e + rng.uniform(-jitter, jitter)
+                jn = n + rng.uniform(-jitter, jitter)
+
+                # Convert back to lat/lon for point-in-polygon test
+                # Approximate inverse: use linear scaling from center
+                lat_per_m = 1.0 / 111320.0
+                lon_per_m = 1.0 / (111320.0 * math.cos(
+                    math.radians(center_lat)))
+                pt_lat = center_lat + jn * lat_per_m
+                pt_lon = center_lon + je * lon_per_m
+
+                pt = ogr.Geometry(ogr.wkbPoint)
+                pt.AddPoint(pt_lon, pt_lat)
+
+                if geom.Contains(pt):
+                    z = _sample_terrain_elevation(
+                        je, jn, terrain, terrain_bounds)
+
+                    # Randomize tree dimensions
+                    scale = 1.0 + rng.uniform(
+                        -_TREE_HEIGHT_VARIANCE, _TREE_HEIGHT_VARIANCE)
+                    trunk_h = _TRUNK_HEIGHT * scale
+                    canopy_h = _CANOPY_HEIGHT * scale
+                    canopy_r = _CANOPY_RADIUS * scale
+                    trunk_r = _TRUNK_RADIUS * scale
+
+                    # Random yaw for visual variety
+                    yaw = rng.uniform(0, 2 * math.pi)
+
+                    tree_models.append(
+                        f'    <model name="tree_{tree_idx:05d}">\n'
+                        f'      <static>true</static>\n'
+                        f'      <pose>{je:.2f} {jn:.2f} {z:.2f}'
+                        f' 0 0 {yaw:.3f}</pose>\n'
+                        f'      <link name="link">\n'
+                        f'        <visual name="trunk">\n'
+                        f'          <pose>0 0 {trunk_h / 2.0:.2f}'
+                        f' 0 0 0</pose>\n'
+                        f'          <geometry>\n'
+                        f'            <cylinder>\n'
+                        f'              <radius>{trunk_r:.2f}</radius>\n'
+                        f'              <length>{trunk_h:.2f}</length>\n'
+                        f'            </cylinder>\n'
+                        f'          </geometry>\n'
+                        f'          <material>\n'
+                        f'            <ambient>0.4 0.25 0.1 1</ambient>\n'
+                        f'            <diffuse>0.5 0.3 0.15 1</diffuse>\n'
+                        f'          </material>\n'
+                        f'        </visual>\n'
+                        f'        <visual name="canopy">\n'
+                        f'          <pose>0 0 '
+                        f'{trunk_h + canopy_h / 2.0:.2f}'
+                        f' 0 0 0</pose>\n'
+                        f'          <geometry>\n'
+                        f'            <cone>\n'
+                        f'              <radius>{canopy_r:.2f}</radius>\n'
+                        f'              <length>{canopy_h:.2f}</length>\n'
+                        f'            </cone>\n'
+                        f'          </geometry>\n'
+                        f'          <material>\n'
+                        f'            <ambient>0.15 0.35 0.1 1</ambient>\n'
+                        f'            <diffuse>0.2 0.45 0.15 1</diffuse>\n'
+                        f'          </material>\n'
+                        f'        </visual>\n'
+                        f'      </link>\n'
+                        f'    </model>'
+                    )
+                    tree_idx += 1
+
+                n += spacing
+            e += spacing
+
+    return tree_models
+
+
 def generate_feature_models(
     features, center_lat, center_lon,
     terrain=None, terrain_bounds=None, debug=False,
@@ -1164,6 +1324,8 @@ def generate_feature_models(
     max_wall_segments=None,
     osm_man_made=None,
     osm_bridge_roads=None,
+    osm_natural=None,
+    max_trees=_TREE_MAX_COUNT,
 ):
     """Convert S57 features to grouped SDF <model> XML strings.
 
@@ -1646,10 +1808,20 @@ def generate_feature_models(
         'pylons': pylons,
         'coastlines': coastlines,
     }
+    # Trees from OSM natural=wood polygons
+    tree_models = []
+    if osm_natural and 'trees' not in skip and max_trees > 0:
+        tree_models = _scatter_trees(
+            osm_natural, center_lat, center_lon, terrain, terrain_bounds,
+            max_trees=max_trees)
+        if tree_models:
+            print(f"  Generated {len(tree_models)} trees")
+
     osm_types = {
         'buildings': osm_buildings,
         'marine': marine_models,
         'bridges': osm_bridge_models,
+        'trees': tree_models,
     }
 
     return {

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/feature_models.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/feature_models.py
@@ -45,6 +45,10 @@ _S57_COLOURS = {
     6: (1.0, 1.0, 0.0),    # yellow
 }
 
+# Default building colors by source (ambient, diffuse)
+_DEFAULT_S57_BUILDING_COLORS = ('0.6 0.6 0.55 1.0', '0.7 0.7 0.65 1.0')  # warm beige
+_DEFAULT_OSM_BUILDING_COLORS = ('0.55 0.58 0.62 1.0', '0.65 0.68 0.72 1.0')  # cool gray-blue
+
 # OSM building:material -> (ambient, diffuse) SDF color strings
 _OSM_MATERIAL_COLORS = {
     'brick':    ('0.6 0.3 0.2 1.0', '0.7 0.4 0.3 1.0'),
@@ -111,8 +115,8 @@ def _osm_material_to_colors(material: str, colour: str):
         if result is not None:
             return result
 
-    # Default building colors
-    return '0.6 0.6 0.55 1.0', '0.7 0.7 0.65 1.0'
+    # Default OSM building colors (callers with S57 data use their own default)
+    return _DEFAULT_OSM_BUILDING_COLORS
 
 
 def _sanitize_objnam(objnam: str) -> str:
@@ -952,9 +956,10 @@ def generate_feature_models(
                 amb, dif = _osm_material_to_colors(
                     building.osm_material, building.osm_colour,
                 )
+            elif building.osm_only:
+                amb, dif = _DEFAULT_OSM_BUILDING_COLORS
             else:
-                amb = '0.6 0.6 0.55 1.0'
-                dif = '0.7 0.7 0.65 1.0'
+                amb, dif = _DEFAULT_S57_BUILDING_COLORS
         # Include OBJNAM in model name if available
         name = f'building_{i:04d}'
         if building.objnam:

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/feature_models.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/feature_models.py
@@ -854,13 +854,49 @@ def _pylon_model(name, x, y, z, height, collision=True):
     )
 
 
+def _wrap_group(group_name, model_lists):
+    """Wrap non-empty model lists into a nested container model.
+
+    Args:
+        group_name: Name for the top-level container (e.g. 's57_features').
+        model_lists: dict mapping type name to list of model XML strings.
+
+    Returns:
+        SDF string for the container model, or empty string if all empty.
+    """
+    type_groups = []
+    for type_name, models in model_lists.items():
+        if not models:
+            continue
+        inner = '\n'.join(f'  {line}' for m in models for line in m.split('\n'))
+        type_groups.append(
+            f'      <model name="{type_name}">\n'
+            f'{inner}\n'
+            f'      </model>'
+        )
+    if not type_groups:
+        return ''
+    inner_xml = '\n'.join(type_groups)
+    return (
+        f'    <model name="{group_name}">\n'
+        f'      <static>true</static>\n'
+        f'{inner_xml}\n'
+        f'    </model>'
+    )
+
+
 def generate_feature_models(
     features, center_lat, center_lon,
     terrain=None, terrain_bounds=None, debug=False,
     skip_categories=None, simplify_tolerance=0.0,
     max_wall_segments=None,
 ):
-    """Convert S57 features to SDF <model> XML strings.
+    """Convert S57 features to grouped SDF <model> XML strings.
+
+    Features are organized into two top-level container models:
+    ``s57_features`` and ``osm_features``, each containing sub-groups
+    by feature type. This creates a 3-level hierarchy in Gazebo's
+    Entity Tree: source -> feature type -> individual models.
 
     Args:
         features: S57Features instance with extracted chart features.
@@ -879,15 +915,19 @@ def generate_feature_models(
             generation.  0 disables simplification.
 
     Returns:
-        String of SDF <model> elements ready to insert into a world template.
-        Empty string if no features to generate.
+        Dict with 's57' and 'osm' keys, each containing an SDF string
+        for the corresponding container model. Values are empty strings
+        if no features to generate for that source.
     """
-    models = []
     skip = skip_categories or set()
 
     # Land features omit collision geometry — they exist for visual context
     # only and don't need physics interaction with vessels.
     _LAND = False
+
+    # Collect models by type for S57 and OSM sources
+    s57_buildings = []
+    osm_buildings = []
 
     # Buildings (BUISGL, LNDMRK, SILTNK)
     for i, building in enumerate(
@@ -927,9 +967,13 @@ def generate_feature_models(
             ambient=amb, diffuse=dif, collision=_LAND,
         )
         if model:
-            models.append(model)
+            if building.osm_only:
+                osm_buildings.append(model)
+            else:
+                s57_buildings.append(model)
 
     # Pontoons (water surface, z=0)
+    pontoons = []
     for i, pontoon in enumerate(
         features.pontoons if 'pontoons' not in skip else []
     ):
@@ -948,7 +992,7 @@ def generate_feature_models(
                 ambient=amb, diffuse=dif,
             )
             if model:
-                models.append(model)
+                pontoons.append(model)
         elif geom_type in (2, 5, 7):  # LineString, Multi, Collection
             wall, _ = _slcons_wall_model(
                 f'pontoon_{i:04d}', pontoon.geometry,
@@ -957,9 +1001,10 @@ def generate_feature_models(
                 ambient=amb, diffuse=dif,
             )
             if wall:
-                models.append(wall)
+                pontoons.append(wall)
 
     # Bridges (deck at clearance height, not extruded from 0)
+    bridges = []
     for i, bridge in enumerate(
         features.bridges if 'bridges' not in skip else []
     ):
@@ -980,7 +1025,7 @@ def generate_feature_models(
                 ambient=amb, diffuse=dif,
             )
             if model:
-                models.append(model)
+                bridges.append(model)
         elif geom_type in (2, 5, 7):  # LineString, Multi, Collection
             wall, _ = _slcons_wall_model(
                 f'bridge_{i:04d}', bridge.geometry,
@@ -989,16 +1034,18 @@ def generate_feature_models(
                 ambient=amb, diffuse=dif,
             )
             if wall:
-                models.append(wall)
+                bridges.append(wall)
 
     # Buoys (water surface, z=0)
+    buoys = []
     for i, buoy in enumerate(
         features.buoys if 'buoys' not in skip else []
     ):
         x, y = _latlon_to_enu(buoy.lat, buoy.lon, center_lat, center_lon)
-        models.append(_buoy_model(f'buoy_{i:04d}', x, y, buoy.colour))
+        buoys.append(_buoy_model(f'buoy_{i:04d}', x, y, buoy.colour))
 
     # Beacons (on terrain)
+    beacons = []
     for i, beacon in enumerate(
         features.beacons if 'beacons' not in skip else []
     ):
@@ -1006,12 +1053,13 @@ def generate_feature_models(
             beacon.lat, beacon.lon, center_lat, center_lon
         )
         z = _sample_terrain_elevation(x, y, terrain, terrain_bounds)
-        models.append(_beacon_model(
+        beacons.append(_beacon_model(
             f'beacon_{i:04d}', x, y, z=z, colour_code=beacon.colour,
             collision=_LAND,
         ))
 
     # Lights (on terrain)
+    lights = []
     for i, light in enumerate(
         features.lights if 'lights' not in skip else []
     ):
@@ -1019,12 +1067,13 @@ def generate_feature_models(
             light.lat, light.lon, center_lat, center_lon
         )
         z = _sample_terrain_elevation(x, y, terrain, terrain_bounds)
-        models.append(_light_model(f'light_{i:04d}', x, y, z=z,
+        lights.append(_light_model(f'light_{i:04d}', x, y, z=z,
                                    tower_height=light.height,
                                    colour_code=light.colour,
                                    collision=_LAND))
 
     # Shore constructions (SLCONS): line, polygon, and point geometry
+    shore_constructions = []
     wall_seg_remaining = max_wall_segments
     for i, sc in enumerate(
         features.shore_constructions if 'shore_constructions' not in skip
@@ -1048,7 +1097,7 @@ def generate_feature_models(
                 seg_budget=wall_seg_remaining,
             )
             if wall:
-                models.append(wall)
+                shore_constructions.append(wall)
             if wall_seg_remaining is not None:
                 wall_seg_remaining -= n_segs
         elif geom_type in (3, 6):  # Polygon, MultiPolygon
@@ -1058,33 +1107,36 @@ def generate_feature_models(
                 ambient=amb, diffuse=dif, collision=_LAND,
             )
             if model:
-                models.append(model)
+                shore_constructions.append(model)
         elif geom_type == 1:  # Point
             x, y = _latlon_to_enu(
                 sc.geometry.GetY(), sc.geometry.GetX(),
                 center_lat, center_lon,
             )
-            models.append(_slcons_point_model(f'slcons_{i:04d}', x, y,
-                                               collision=_LAND))
+            shore_constructions.append(_slcons_point_model(
+                f'slcons_{i:04d}', x, y, collision=_LAND))
 
     # Piles (at water level)
+    piles = []
     for i, pile in enumerate(
         features.piles if 'piles' not in skip else []
     ):
         x, y = _latlon_to_enu(pile.lat, pile.lon, center_lat, center_lon)
-        models.append(_pile_model(f'pile_{i:04d}', x, y))
+        piles.append(_pile_model(f'pile_{i:04d}', x, y))
 
     # Mooring facilities
+    mooring_facilities = []
     for i, mf in enumerate(
         features.mooring_facilities if 'mooring_facilities' not in skip
         else []
     ):
         x, y = _latlon_to_enu(mf.lat, mf.lon, center_lat, center_lon)
         z = _sample_terrain_elevation(x, y, terrain, terrain_bounds)
-        models.append(_morfac_model(f'morfac_{i:04d}', x, y, z, mf.catmor,
-                                    collision=_LAND))
+        mooring_facilities.append(_morfac_model(
+            f'morfac_{i:04d}', x, y, z, mf.catmor, collision=_LAND))
 
     # Cranes (on terrain)
+    cranes = []
     for i, crane in enumerate(
         features.cranes if 'cranes' not in skip else []
     ):
@@ -1092,12 +1144,13 @@ def generate_feature_models(
             crane.lat, crane.lon, center_lat, center_lon
         )
         z = _sample_terrain_elevation(x, y, terrain, terrain_bounds)
-        models.append(_crane_model(
+        cranes.append(_crane_model(
             f'crane_{i:04d}', x, y, z, crane.catcrn, crane.height,
             collision=_LAND,
         ))
 
     # Pylons (on terrain)
+    pylons = []
     for i, pylon in enumerate(
         features.pylons if 'pylons' not in skip else []
     ):
@@ -1105,12 +1158,13 @@ def generate_feature_models(
             pylon.lat, pylon.lon, center_lat, center_lon
         )
         z = _sample_terrain_elevation(x, y, terrain, terrain_bounds)
-        models.append(_pylon_model(
+        pylons.append(_pylon_model(
             f'pylon_{i:04d}', x, y, z, pylon.height,
             collision=_LAND,
         ))
 
     # Debug: coastline walls (simplified to reduce segment count)
+    coastlines = []
     if debug and features.coastlines:
         for i, coastline in enumerate(features.coastlines):
             tol = simplify_tolerance if simplify_tolerance > 0 else 0.0002
@@ -1120,9 +1174,28 @@ def generate_feature_models(
                 center_lat, center_lon,
             )
             if wall:
-                models.append(wall)
+                coastlines.append(wall)
 
-    if not models:
-        return ''
+    # Build grouped container models
+    s57_types = {
+        'buildings': s57_buildings,
+        'pontoons': pontoons,
+        'bridges': bridges,
+        'buoys': buoys,
+        'beacons': beacons,
+        'lights': lights,
+        'shore_constructions': shore_constructions,
+        'piles': piles,
+        'mooring_facilities': mooring_facilities,
+        'cranes': cranes,
+        'pylons': pylons,
+        'coastlines': coastlines,
+    }
+    osm_types = {
+        'buildings': osm_buildings,
+    }
 
-    return '\n\n'.join(models)
+    return {
+        's57': _wrap_group('s57_features', s57_types),
+        'osm': _wrap_group('osm_features', osm_types),
+    }

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/feature_models.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/feature_models.py
@@ -1095,9 +1095,13 @@ def generate_feature_models(
         height, wall_width, amb, dif = params
         # Enriched pier: use OSM polygon instead of S57 linestring
         if sc.osm_geometry is not None:
+            centroid = sc.osm_geometry.Centroid()
+            cx, cy = _latlon_to_enu(
+                centroid.GetY(), centroid.GetX(), center_lat, center_lon)
+            z = _sample_terrain_elevation(cx, cy, terrain, terrain_bounds)
             model = _polygon_to_polyline_model(
                 f'slcons_{i:04d}', sc.osm_geometry,
-                center_lat, center_lon, height, z=0.0,
+                center_lat, center_lon, 0.5, z=z,
                 ambient=amb, diffuse=dif, collision=_LAND,
             )
             if model:

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/feature_models.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/feature_models.py
@@ -1091,9 +1091,19 @@ def generate_feature_models(
         catslc_skip = _CATSLC_SKIP_NAME.get(sc.catslc)
         if catslc_skip and catslc_skip in skip:
             continue
-        geom_type = sc.geometry.GetGeometryType() & 0xFF
         params = _SLCONS_PARAMS.get(sc.catslc, _SLCONS_DEFAULT)
         height, wall_width, amb, dif = params
+        # Enriched pier: use OSM polygon instead of S57 linestring
+        if sc.osm_geometry is not None:
+            model = _polygon_to_polyline_model(
+                f'slcons_{i:04d}', sc.osm_geometry,
+                center_lat, center_lon, height, z=0.0,
+                ambient=amb, diffuse=dif, collision=_LAND,
+            )
+            if model:
+                shore_constructions.append(model)
+            continue
+        geom_type = sc.geometry.GetGeometryType() & 0xFF
         if geom_type in (2, 5, 7):  # LineString, MultiLineString, Collection
             wall, n_segs = _slcons_wall_model(
                 f'slcons_{i:04d}', sc.geometry,

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/feature_models.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/feature_models.py
@@ -894,6 +894,7 @@ def generate_feature_models(
     terrain=None, terrain_bounds=None, debug=False,
     skip_categories=None, simplify_tolerance=0.0,
     max_wall_segments=None,
+    osm_man_made=None, osm_roads=None,
 ):
     """Convert S57 features to grouped SDF <model> XML strings.
 
@@ -1181,6 +1182,63 @@ def generate_feature_models(
             if wall:
                 coastlines.append(wall)
 
+    # Marine infrastructure from OSM (piers, quays, breakwaters, groynes)
+    _MARINE_COLORS = {
+        'pier': ('0.65 0.62 0.58 1.0', '0.75 0.72 0.68 1.0'),
+        'quay': ('0.55 0.55 0.53 1.0', '0.65 0.65 0.63 1.0'),
+        'breakwater': ('0.45 0.45 0.43 1.0', '0.55 0.55 0.53 1.0'),
+        'groyne': ('0.45 0.45 0.43 1.0', '0.55 0.55 0.53 1.0'),
+    }
+    _MARINE_DEFAULT_COLOR = ('0.55 0.55 0.53 1.0', '0.65 0.65 0.63 1.0')
+    marine_models = []
+    for i, mm in enumerate(osm_man_made or []):
+        amb, dif = _MARINE_COLORS.get(mm.man_made, _MARINE_DEFAULT_COLOR)
+        geom_type = mm.geometry.GetGeometryType() & 0xFF
+        if geom_type in (3, 6):  # Polygon — flat extruded slab
+            centroid = mm.geometry.Centroid()
+            cx, cy = _latlon_to_enu(
+                centroid.GetY(), centroid.GetX(), center_lat, center_lon)
+            z = _sample_terrain_elevation(cx, cy, terrain, terrain_bounds)
+            model = _polygon_to_polyline_model(
+                f'marine_{i:04d}_{mm.man_made}', mm.geometry,
+                center_lat, center_lon, 1.0, z=z,
+                ambient=amb, diffuse=dif, collision=False,
+            )
+            if model:
+                marine_models.append(model)
+        elif geom_type in (2, 5, 7):  # LineString — wall segments
+            wall_width = 3.0 if mm.man_made in ('breakwater', 'groyne') else 2.0
+            height = 2.0 if mm.man_made in ('breakwater', 'groyne') else 1.0
+            wall, _ = _slcons_wall_model(
+                f'marine_{i:04d}_{mm.man_made}', mm.geometry,
+                center_lat, center_lon,
+                height=height, wall_width=wall_width,
+                ambient=amb, diffuse=dif, collision=False,
+            )
+            if wall:
+                marine_models.append(wall)
+
+    # Roads from OSM (flat strips for debugging)
+    _ROAD_WIDTHS = {
+        'motorway': 12.0, 'trunk': 10.0, 'primary': 9.0,
+        'secondary': 8.0, 'tertiary': 7.0, 'residential': 6.0,
+        'unclassified': 5.0, 'service': 4.0, 'track': 3.0,
+        'footway': 1.5, 'path': 1.5, 'cycleway': 2.0, 'steps': 1.5,
+    }
+    _ROAD_AMB = '0.3 0.3 0.3 1.0'
+    _ROAD_DIF = '0.4 0.4 0.4 1.0'
+    road_models = []
+    for i, road in enumerate(osm_roads or []):
+        width = _ROAD_WIDTHS.get(road.highway, 4.0)
+        wall, _ = _slcons_wall_model(
+            f'road_{i:04d}_{road.highway}', road.geometry,
+            center_lat, center_lon,
+            height=0.15, wall_width=width, z=0.1,
+            ambient=_ROAD_AMB, diffuse=_ROAD_DIF, collision=False,
+        )
+        if wall:
+            road_models.append(wall)
+
     # Build grouped container models
     s57_types = {
         'buildings': s57_buildings,
@@ -1198,6 +1256,8 @@ def generate_feature_models(
     }
     osm_types = {
         'buildings': osm_buildings,
+        'marine': marine_models,
+        'roads': road_models,
     }
 
     return {

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/feature_models.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/feature_models.py
@@ -1225,8 +1225,8 @@ def generate_feature_models(
         'unclassified': 5.0, 'service': 4.0, 'track': 3.0,
         'footway': 1.5, 'path': 1.5, 'cycleway': 2.0, 'steps': 1.5,
     }
-    _ROAD_AMB = '0.3 0.3 0.3 1.0'
-    _ROAD_DIF = '0.4 0.4 0.4 1.0'
+    _ROAD_AMB = '0.6 0.5 0.2 1.0'
+    _ROAD_DIF = '0.8 0.7 0.3 1.0'
     _ROAD_DASH_LEN = 5.0    # meters per dash segment
     _ROAD_DASH_GAP = 50.0   # meters between dash starts
     _ROAD_HEIGHT = 0.15     # dash thickness
@@ -1267,13 +1267,15 @@ def generate_feature_models(
                     dist_since_dash = 0.0
                     mx = (x0 + x1) / 2.0
                     my = (y0 + y1) / 2.0
+                    mz = _sample_terrain_elevation(
+                        mx, my, terrain, terrain_bounds)
                     yaw = math.atan2(dy, dx)
                     dash_len = min(_ROAD_DASH_LEN, seg_len)
                     road_models.append(
                         f'    <model name="road_{road_seg_idx:05d}">\n'
                         f'      <static>true</static>\n'
                         f'      <pose>{mx:.2f} {my:.2f} '
-                        f'{_ROAD_HEIGHT / 2 + _ROAD_Z:.2f} '
+                        f'{mz + _ROAD_HEIGHT / 2 + _ROAD_Z:.2f} '
                         f'0 0 {yaw:.4f}</pose>\n'
                         f'      <link name="link">\n'
                         f'        <visual name="visual">\n'

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/generate_world.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/generate_world.py
@@ -411,15 +411,17 @@ def main(argv=None):
                     "size_x": tile_size_x, "size_y": tile_size_y,
                 }
                 print("  Rasterizing OSM terrain texture...")
+                tile_center_lat = (tile_bbox.south + tile_bbox.north) / 2
+                tile_center_lon = (tile_bbox.west + tile_bbox.east) / 2
                 land_texture, osm_tex_size = rasterize_osm_texture(
                     osm_features, tile_terrain_info, grid_size,
-                    ref_lat, ref_lon,
+                    tile_center_lat, tile_center_lon,
                 )
 
             terrain, terrain_info, heightmap_info = _build_single_tile(
                 args, tile_bbox, grid_size, s57_features,
                 ref_lat=ref_lat, ref_lon=ref_lon,
-                model_name=f"terrain_{name}",
+                model_name=f"{args.world_name}_terrain_{name}",
                 land_texture=land_texture,
             )
             if osm_tex_size is not None:
@@ -474,6 +476,11 @@ def main(argv=None):
         )
         if osm_tex_size is not None:
             heightmap_info["osm_tex_size"] = osm_tex_size
+            # Rewrite model.sdf with updated tex_size
+            from .heightmap import _write_model_sdf
+            model_dir = os.path.join(args.output_dir,
+                                     heightmap_info["model_name"])
+            _write_model_sdf(model_dir, heightmap_info)
         heightmap_result = heightmap_info
 
     # Step 5: Generate feature models (optional)

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/generate_world.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/generate_world.py
@@ -365,13 +365,14 @@ def main(argv=None):
 
             # Rasterize OSM texture for this tile
             land_texture = None
+            osm_tex_size = None
             if osm_features is not None:
                 tile_size_x, tile_size_y = _bbox_size_meters(tile_bbox)
                 tile_terrain_info = {
                     "size_x": tile_size_x, "size_y": tile_size_y,
                 }
                 print("  Rasterizing OSM terrain texture...")
-                land_texture = rasterize_osm_texture(
+                land_texture, osm_tex_size = rasterize_osm_texture(
                     osm_features, tile_terrain_info, grid_size,
                     ref_lat, ref_lon,
                 )
@@ -382,6 +383,8 @@ def main(argv=None):
                 model_name=f"terrain_{name}",
                 land_texture=land_texture,
             )
+            if osm_tex_size is not None:
+                heightmap_info["osm_tex_size"] = osm_tex_size
             # Embed ENU offset directly in the heightmap <pos> element
             # (Gazebo's OGRE2 heightmap renderer uses <pos>, not model pose)
             enu_x, enu_y = _bbox_center_enu(
@@ -407,13 +410,14 @@ def main(argv=None):
 
         # Rasterize OSM texture for the single tile
         land_texture = None
+        osm_tex_size = None
         if osm_features is not None:
             tile_size_x, tile_size_y = _bbox_size_meters(tile_bbox)
             tile_terrain_info = {
                 "size_x": tile_size_x, "size_y": tile_size_y,
             }
             print("Rasterizing OSM terrain texture...")
-            land_texture = rasterize_osm_texture(
+            land_texture, osm_tex_size = rasterize_osm_texture(
                 osm_features, tile_terrain_info, grid_size,
                 ref_lat, ref_lon,
             )
@@ -429,6 +433,8 @@ def main(argv=None):
             model_name=f"{args.world_name}_terrain",
             land_texture=land_texture,
         )
+        if osm_tex_size is not None:
+            heightmap_info["osm_tex_size"] = osm_tex_size
         heightmap_result = heightmap_info
 
     # Step 5: Generate feature models (optional)

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/generate_world.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/generate_world.py
@@ -205,6 +205,14 @@ def parse_args(argv=None):
         help="Maximum number of wall segments for shore constructions. "
         "Limits the total SLCONS segment count across all features.",
     )
+    parser.add_argument(
+        "--max-trees",
+        type=int,
+        default=500,
+        help="Maximum number of tree models to generate. Tree spacing "
+        "is adjusted automatically to stay under this cap. "
+        "Set to 0 to disable trees. Default: 500.",
+    )
     return parser.parse_args(argv)
 
 
@@ -507,6 +515,8 @@ def main(argv=None):
             osm_man_made=osm_features.man_made if osm_features else None,
             osm_bridge_roads=[r for r in osm_features.roads if r.bridge]
             if osm_features else None,
+            osm_natural=osm_features.natural if osm_features else None,
+            max_trees=args.max_trees,
         )
         s57_feature_sdf = feature_groups['s57']
         osm_feature_sdf = feature_groups['osm']

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/generate_world.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/generate_world.py
@@ -26,6 +26,7 @@ from .feature_models import generate_feature_models
 from .heightmap import terrain_to_heightmap
 from .osm_fetcher import fetch_osm_features
 from .osm_matcher import match_and_enrich
+from .osm_texture import rasterize_osm_texture
 from .s57_reader import BoundingBox, read_enc_directory
 from .terrain import build_terrain
 from .world_builder import generate_world_sdf
@@ -193,7 +194,8 @@ def parse_args(argv=None):
 
 
 def _build_single_tile(args, bbox, grid_size, s57_features,
-                       ref_lat, ref_lon, model_name="terrain"):
+                       ref_lat, ref_lon, model_name="terrain",
+                       land_texture=None):
     """Build terrain and heightmap for a single tile.
 
     Returns (terrain_array, terrain_info, heightmap_info).
@@ -227,6 +229,7 @@ def _build_single_tile(args, bbox, grid_size, s57_features,
     print(f"  Generating heightmap for {model_name}...")
     heightmap_info = terrain_to_heightmap(
         terrain, terrain_info, args.output_dir, model_name=model_name,
+        land_texture=land_texture,
     )
     print(f"    Saved to {heightmap_info['heightmap_path']}")
 
@@ -313,18 +316,28 @@ def main(argv=None):
             )
 
     # Step 1.5: OSM enrichment (optional)
-    if args.osm and s57_features is not None:
+    osm_features = None
+    if args.osm:
         try:
-            print("Fetching OSM data...")
-            osm_features = fetch_osm_features(bbox, cache_dir=args.cache_dir)
-            print(f"  Found {len(osm_features.buildings)} OSM buildings")
-            s57_features, n_matched, n_added = match_and_enrich(
-                s57_features, osm_features,
+            print("Fetching OSM data (with terrain features)...")
+            osm_features = fetch_osm_features(
+                bbox, cache_dir=args.cache_dir,
+                fetch_terrain_features=True,
             )
-            print(f"  Matched {n_matched} S57 buildings with OSM data")
-            print(f"  Added {n_added} OSM-only buildings")
+            print(f"  Found {len(osm_features.buildings)} OSM buildings, "
+                  f"{len(osm_features.landuse)} landuse, "
+                  f"{len(osm_features.roads)} roads, "
+                  f"{len(osm_features.parking)} parking, "
+                  f"{len(osm_features.natural)} natural areas")
+            if s57_features is not None:
+                s57_features, n_matched, n_added = match_and_enrich(
+                    s57_features, osm_features,
+                )
+                print(f"  Matched {n_matched} S57 buildings with OSM data")
+                print(f"  Added {n_added} OSM-only buildings")
         except Exception as e:
             print(f"  Warning: OSM enrichment failed, skipping: {e}")
+            osm_features = None
 
     # Step 2-4: Build terrain tiles
     ref_lat = bbox.center_lat
@@ -339,10 +352,25 @@ def main(argv=None):
         for name, tile_bbox, grid_power in tiles:
             grid_size = 2 ** grid_power + 1
             print(f"\nTile '{name}' ({grid_size}x{grid_size}):")
+
+            # Rasterize OSM texture for this tile
+            land_texture = None
+            if osm_features is not None:
+                tile_size_x, tile_size_y = _bbox_size_meters(tile_bbox)
+                tile_terrain_info = {
+                    "size_x": tile_size_x, "size_y": tile_size_y,
+                }
+                print("  Rasterizing OSM terrain texture...")
+                land_texture = rasterize_osm_texture(
+                    osm_features, tile_terrain_info, grid_size,
+                    ref_lat, ref_lon,
+                )
+
             terrain, terrain_info, heightmap_info = _build_single_tile(
                 args, tile_bbox, grid_size, s57_features,
                 ref_lat=ref_lat, ref_lon=ref_lon,
                 model_name=f"terrain_{name}",
+                land_texture=land_texture,
             )
             # Embed ENU offset directly in the heightmap <pos> element
             # (Gazebo's OGRE2 heightmap renderer uses <pos>, not model pose)
@@ -366,10 +394,29 @@ def main(argv=None):
         grid_size = 2 ** grid_power + 1
         if not args.fetch_etopo:
             print("Using S57-only terrain (land ramp + soundings).")
+
+        # Rasterize OSM texture for the single tile
+        land_texture = None
+        if osm_features is not None:
+            tile_size_x, tile_size_y = _bbox_size_meters(tile_bbox)
+            tile_terrain_info = {
+                "size_x": tile_size_x, "size_y": tile_size_y,
+            }
+            print("Rasterizing OSM terrain texture...")
+            land_texture = rasterize_osm_texture(
+                osm_features, tile_terrain_info, grid_size,
+                ref_lat, ref_lon,
+            )
+            n_features = (len(osm_features.landuse) + len(osm_features.roads)
+                          + len(osm_features.parking) + len(osm_features.natural))
+            print(f"  Rasterized {n_features} terrain features "
+                  f"onto {grid_size}x{grid_size} texture")
+
         first_terrain, first_terrain_info, heightmap_info = _build_single_tile(
             args, tile_bbox, grid_size, s57_features,
             ref_lat=ref_lat, ref_lon=ref_lon,
             model_name=f"{args.world_name}_terrain",
+            land_texture=land_texture,
         )
         heightmap_result = heightmap_info
 

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/generate_world.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/generate_world.py
@@ -336,7 +336,8 @@ def main(argv=None):
                   f"{len(osm_features.landuse)} landuse, "
                   f"{len(osm_features.roads)} roads, "
                   f"{len(osm_features.parking)} parking, "
-                  f"{len(osm_features.natural)} natural areas")
+                  f"{len(osm_features.natural)} natural, "
+                  f"{len(osm_features.man_made)} marine infrastructure")
             if s57_features is not None:
                 s57_features, n_matched, n_added = match_and_enrich(
                     s57_features, osm_features,
@@ -417,7 +418,8 @@ def main(argv=None):
                 ref_lat, ref_lon,
             )
             n_features = (len(osm_features.landuse) + len(osm_features.roads)
-                          + len(osm_features.parking) + len(osm_features.natural))
+                          + len(osm_features.parking) + len(osm_features.natural)
+                          + len(osm_features.man_made))
             print(f"  Rasterized {n_features} terrain features "
                   f"onto {grid_size}x{grid_size} texture")
 
@@ -465,6 +467,8 @@ def main(argv=None):
             skip_categories=skip_categories,
             simplify_tolerance=simplify_tol,
             max_wall_segments=args.max_wall_segments,
+            osm_man_made=osm_features.man_made if osm_features else None,
+            osm_roads=osm_features.roads if osm_features else None,
         )
         s57_feature_sdf = feature_groups['s57']
         osm_feature_sdf = feature_groups['osm']

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/generate_world.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/generate_world.py
@@ -25,7 +25,7 @@ from .coordinates import latlon_to_enu
 from .feature_models import generate_feature_models
 from .heightmap import terrain_to_heightmap
 from .osm_fetcher import fetch_osm_features
-from .osm_matcher import match_and_enrich
+from .osm_matcher import match_and_enrich, match_piers
 from .osm_texture import rasterize_osm_texture
 from .s57_reader import BoundingBox, read_enc_directory
 from .terrain import build_terrain
@@ -345,6 +345,28 @@ def main(argv=None):
                 )
                 print(f"  Matched {n_matched} S57 buildings with OSM data")
                 print(f"  Added {n_added} OSM-only buildings")
+                s57_features, n_pier_matched, n_pier_added, matched_pier_indices = match_piers(
+                    s57_features, osm_features,
+                    add_unmatched=not args.no_osm_buildings,
+                )
+                print(f"  Pier matching: {n_pier_matched} matched, {n_pier_added} added")
+                # Remove OSM piers from man_made to avoid double rendering.
+                # When add_unmatched is true, all pier polygons are handled
+                # via SLCONS (matched or added), so filter them all out.
+                if n_pier_matched or n_pier_added:
+                    if not args.no_osm_buildings:
+                        # All pier polygons consumed — remove them all
+                        osm_features.man_made = [
+                            mm for mm in osm_features.man_made
+                            if not (mm.man_made == 'pier'
+                                    and (mm.geometry.GetGeometryType() & 0xFF) in (3, 6))
+                        ]
+                    elif matched_pier_indices:
+                        # Only remove matched ones
+                        osm_features.man_made = [
+                            mm for idx, mm in enumerate(osm_features.man_made)
+                            if idx not in matched_pier_indices
+                        ]
         except Exception as e:
             print(f"  Warning: OSM enrichment failed, skipping: {e}")
             osm_features = None

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/generate_world.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/generate_world.py
@@ -27,7 +27,7 @@ from .heightmap import terrain_to_heightmap
 from .osm_fetcher import fetch_osm_features
 from .osm_matcher import match_and_enrich, match_piers
 from .osm_texture import rasterize_osm_texture
-from .s57_reader import BoundingBox, read_enc_directory
+from .s57_reader import BoundingBox, S57Features, read_enc_directory
 from .terrain import build_terrain
 from .world_builder import generate_world_sdf
 
@@ -218,7 +218,7 @@ def parse_args(argv=None):
 
 def _build_single_tile(args, bbox, grid_size, s57_features,
                        ref_lat, ref_lon, model_name="terrain",
-                       land_texture=None):
+                       land_texture=None, osm_tex_size=None):
     """Build terrain and heightmap for a single tile.
 
     Returns (terrain_array, terrain_info, heightmap_info).
@@ -252,7 +252,7 @@ def _build_single_tile(args, bbox, grid_size, s57_features,
     print(f"  Generating heightmap for {model_name}...")
     heightmap_info = terrain_to_heightmap(
         terrain, terrain_info, args.output_dir, model_name=model_name,
-        land_texture=land_texture,
+        land_texture=land_texture, osm_tex_size=osm_tex_size,
     )
     print(f"    Saved to {heightmap_info['heightmap_path']}")
 
@@ -422,10 +422,8 @@ def main(argv=None):
                 args, tile_bbox, grid_size, s57_features,
                 ref_lat=ref_lat, ref_lon=ref_lon,
                 model_name=f"{args.world_name}_terrain_{name}",
-                land_texture=land_texture,
+                land_texture=land_texture, osm_tex_size=osm_tex_size,
             )
-            if osm_tex_size is not None:
-                heightmap_info["osm_tex_size"] = osm_tex_size
             # Embed ENU offset directly in the heightmap <pos> element
             # (Gazebo's OGRE2 heightmap renderer uses <pos>, not model pose)
             enu_x, enu_y = _bbox_center_enu(
@@ -433,7 +431,8 @@ def main(argv=None):
             )
             heightmap_info["pos_x"] = enu_x
             heightmap_info["pos_y"] = enu_y
-            # Rewrite model.sdf with updated position
+            # Rewrite model.sdf with updated position (must happen after
+            # _build_single_tile since ENU offset isn't known beforehand)
             from .heightmap import _write_model_sdf
             model_dir = os.path.join(args.output_dir, heightmap_info["model_name"])
             _write_model_sdf(model_dir, heightmap_info)
@@ -472,15 +471,8 @@ def main(argv=None):
             args, tile_bbox, grid_size, s57_features,
             ref_lat=ref_lat, ref_lon=ref_lon,
             model_name=f"{args.world_name}_terrain",
-            land_texture=land_texture,
+            land_texture=land_texture, osm_tex_size=osm_tex_size,
         )
-        if osm_tex_size is not None:
-            heightmap_info["osm_tex_size"] = osm_tex_size
-            # Rewrite model.sdf with updated tex_size
-            from .heightmap import _write_model_sdf
-            model_dir = os.path.join(args.output_dir,
-                                     heightmap_info["model_name"])
-            _write_model_sdf(model_dir, heightmap_info)
         heightmap_result = heightmap_info
 
     # Step 5: Generate feature models (optional)
@@ -510,10 +502,11 @@ def main(argv=None):
             'max_north': n_ne,
         }
 
-    if not args.no_features and s57_features is not None:
+    if not args.no_features and (s57_features is not None
+                                    or osm_features is not None):
         print("Generating feature models...")
         feature_groups = generate_feature_models(
-            s57_features, ref_lat, ref_lon,
+            s57_features or S57Features(), ref_lat, ref_lon,
             terrain=first_terrain, terrain_bounds=terrain_bounds,
             debug=args.debug_features,
             skip_categories=skip_categories,

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/generate_world.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/generate_world.py
@@ -166,7 +166,15 @@ def parse_args(argv=None):
         "--osm",
         action="store_true",
         help="Enrich S57 buildings with OpenStreetMap data (heights, "
-        "materials, colours) via the Overpass API.",
+        "materials, colours) and rasterize terrain textures via the "
+        "Overpass API.",
+    )
+    parser.add_argument(
+        "--no-osm-buildings",
+        action="store_true",
+        help="When used with --osm, skip adding unmatched OSM-only "
+        "buildings. Only enrich existing S57 buildings and generate "
+        "terrain textures.",
     )
     parser.add_argument(
         "--skip-categories",
@@ -332,6 +340,7 @@ def main(argv=None):
             if s57_features is not None:
                 s57_features, n_matched, n_added = match_and_enrich(
                     s57_features, osm_features,
+                    add_unmatched=not args.no_osm_buildings,
                 )
                 print(f"  Matched {n_matched} S57 buildings with OSM data")
                 print(f"  Added {n_added} OSM-only buildings")

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/generate_world.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/generate_world.py
@@ -430,7 +430,8 @@ def main(argv=None):
         heightmap_result = heightmap_info
 
     # Step 5: Generate feature models (optional)
-    feature_sdf = ""
+    s57_feature_sdf = ""
+    osm_feature_sdf = ""
     skip_categories = set()
     if args.skip_categories:
         skip_categories = {c.strip() for c in args.skip_categories.split(',')}
@@ -456,8 +457,8 @@ def main(argv=None):
         }
 
     if not args.no_features and s57_features is not None:
-        print("Generating S57 feature models...")
-        feature_sdf = generate_feature_models(
+        print("Generating feature models...")
+        feature_groups = generate_feature_models(
             s57_features, ref_lat, ref_lon,
             terrain=first_terrain, terrain_bounds=terrain_bounds,
             debug=args.debug_features,
@@ -465,8 +466,11 @@ def main(argv=None):
             simplify_tolerance=simplify_tol,
             max_wall_segments=args.max_wall_segments,
         )
-        if feature_sdf:
-            n_models = feature_sdf.count("<model name=")
+        s57_feature_sdf = feature_groups['s57']
+        osm_feature_sdf = feature_groups['osm']
+        total = s57_feature_sdf + osm_feature_sdf
+        if total:
+            n_models = total.count("<model name=")
             print(f"  Generated {n_models} feature models")
         else:
             print("  No placeable features found")
@@ -487,7 +491,8 @@ def main(argv=None):
         output_dir=args.output_dir,
         heightmap_info=heightmap_result,
         camera_config=camera_config or None,
-        feature_models=feature_sdf,
+        s57_feature_models=s57_feature_sdf,
+        osm_feature_models=osm_feature_sdf,
         water_size_x=water_x,
         water_size_y=water_y,
     )

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/generate_world.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/generate_world.py
@@ -177,6 +177,13 @@ def parse_args(argv=None):
         "terrain textures.",
     )
     parser.add_argument(
+        "--osm-matching",
+        action="store_true",
+        help="When used with --osm, match S57 and OSM features and merge "
+        "them (e.g. enrich S57 buildings with OSM heights/materials). "
+        "By default, both data sources are rendered independently.",
+    )
+    parser.add_argument(
         "--skip-categories",
         help="Comma-separated list of feature categories to skip. "
         "Valid categories: buildings, pontoons, bridges, buoys, beacons, "
@@ -338,7 +345,7 @@ def main(argv=None):
                   f"{len(osm_features.parking)} parking, "
                   f"{len(osm_features.natural)} natural, "
                   f"{len(osm_features.man_made)} marine infrastructure")
-            if s57_features is not None:
+            if s57_features is not None and args.osm_matching:
                 s57_features, n_matched, n_added = match_and_enrich(
                     s57_features, osm_features,
                     add_unmatched=not args.no_osm_buildings,
@@ -367,6 +374,8 @@ def main(argv=None):
                             mm for idx, mm in enumerate(osm_features.man_made)
                             if idx not in matched_pier_indices
                         ]
+            elif s57_features is not None and not args.osm_matching:
+                print("  Rendering S57 and OSM features independently")
         except Exception as e:
             print(f"  Warning: OSM enrichment failed, skipping: {e}")
             osm_features = None
@@ -496,6 +505,8 @@ def main(argv=None):
             simplify_tolerance=simplify_tol,
             max_wall_segments=args.max_wall_segments,
             osm_man_made=osm_features.man_made if osm_features else None,
+            osm_bridge_roads=[r for r in osm_features.roads if r.bridge]
+            if osm_features else None,
         )
         s57_feature_sdf = feature_groups['s57']
         osm_feature_sdf = feature_groups['osm']

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/generate_world.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/generate_world.py
@@ -474,7 +474,6 @@ def main(argv=None):
             simplify_tolerance=simplify_tol,
             max_wall_segments=args.max_wall_segments,
             osm_man_made=osm_features.man_made if osm_features else None,
-            osm_roads=osm_features.roads if osm_features else None,
         )
         s57_feature_sdf = feature_groups['s57']
         osm_feature_sdf = feature_groups['osm']

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/heightmap.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/heightmap.py
@@ -200,7 +200,7 @@ def _write_model_sdf(model_dir: str, info: dict):
     # Land texture <size>: use terrain dimensions for 1:1 mapping when
     # an OSM-rasterized texture is present, otherwise tile at 10m.
     if info.get("has_osm_texture"):
-        land_tex_size = f"{info['size_x']:.1f}"
+        land_tex_size = f"{info.get('osm_tex_size', info['size_x']):.1f}"
     else:
         land_tex_size = "10"
 

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/heightmap.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/heightmap.py
@@ -15,6 +15,7 @@
 """Generate Gazebo-compatible heightmap PNG from terrain data."""
 
 import os
+from typing import Optional
 
 import numpy as np
 from PIL import Image
@@ -25,6 +26,7 @@ def terrain_to_heightmap(
     terrain_info: dict,
     output_dir: str,
     model_name: str = "terrain",
+    land_texture: Optional[Image.Image] = None,
 ) -> dict:
     """Convert a terrain elevation grid to a 16-bit PNG heightmap.
 
@@ -37,6 +39,9 @@ def terrain_to_heightmap(
         output_dir: Directory to write heightmap files into.
         model_name: Gazebo model name for the terrain. Must be globally
             unique across all worlds (e.g. 'portsmouth_nh_harbor_terrain').
+        land_texture: Optional PIL Image to use as land diffuse texture.
+            If provided, replaces the 16x16 placeholder and sets the SDF
+            texture size to match terrain dimensions for 1:1 mapping.
 
     Returns:
         dict with keys needed for SDF generation:
@@ -84,7 +89,8 @@ def terrain_to_heightmap(
     img.save(heightmap_path)
 
     # Generate terrain textures required by OGRE2's heightmap shader
-    _write_terrain_textures(model_dir, terrain_clean, terrain_info)
+    _write_terrain_textures(model_dir, terrain_clean, terrain_info,
+                            land_texture=land_texture)
 
     # Write model.config
     _write_model_config(model_dir, model_name)
@@ -101,6 +107,7 @@ def terrain_to_heightmap(
         "pos_z": min_elev,
         "min_elevation": min_elev,
         "max_elevation": max_elev,
+        "has_osm_texture": land_texture is not None,
     }
     _write_model_sdf(model_dir, heightmap_info)
 
@@ -108,12 +115,20 @@ def terrain_to_heightmap(
 
 
 def _write_terrain_textures(model_dir: str, terrain: np.ndarray,
-                            terrain_info: dict):
+                            terrain_info: dict,
+                            land_texture: Optional[Image.Image] = None):
     """Generate diffuse and normal map textures for the heightmap.
 
     OGRE2's terrain shader requires at least one texture layer in the
     visual heightmap; without it the generated shader fails to compile.
     Normal maps are computed from the terrain gradient for proper shading.
+
+    Args:
+        model_dir: Directory to write texture files into.
+        terrain: Cleaned elevation grid.
+        terrain_info: dict with size_x, size_y from build_terrain().
+        land_texture: Optional high-resolution land texture from OSM
+            rasterization. If None, a 16x16 solid-color placeholder is used.
     """
     textures_dir = os.path.join(model_dir, "textures")
     os.makedirs(textures_dir, exist_ok=True)
@@ -122,9 +137,12 @@ def _write_terrain_textures(model_dir: str, terrain: np.ndarray,
     diffuse = Image.new("RGB", (16, 16), (160, 145, 120))
     diffuse.save(os.path.join(textures_dir, "seafloor_diffuse.png"))
 
-    # Land diffuse: muted green-brown
-    land = Image.new("RGB", (16, 16), (120, 140, 95))
-    land.save(os.path.join(textures_dir, "land_diffuse.png"))
+    # Land diffuse: use provided texture or placeholder
+    if land_texture is not None:
+        land_texture.save(os.path.join(textures_dir, "land_diffuse.png"))
+    else:
+        land = Image.new("RGB", (16, 16), (120, 140, 95))
+        land.save(os.path.join(textures_dir, "land_diffuse.png"))
 
     # Compute normal map from terrain gradients
     # Pixel spacing in meters
@@ -178,6 +196,14 @@ def _write_model_sdf(model_dir: str, info: dict):
     blend_height = -info["pos_z"]
 
     mn = info['model_name']
+
+    # Land texture <size>: use terrain dimensions for 1:1 mapping when
+    # an OSM-rasterized texture is present, otherwise tile at 10m.
+    if info.get("has_osm_texture"):
+        land_tex_size = f"{info['size_x']:.1f}"
+    else:
+        land_tex_size = "10"
+
     sdf = f"""\
 <?xml version="1.0"?>
 <sdf version="1.9">
@@ -196,7 +222,7 @@ def _write_model_sdf(model_dir: str, info: dict):
             <texture>
               <diffuse>model://{mn}/textures/land_diffuse.png</diffuse>
               <normal>model://{mn}/textures/terrain_normal.png</normal>
-              <size>10</size>
+              <size>{land_tex_size}</size>
             </texture>
             <blend>
               <min_height>{blend_height:.1f}</min_height>

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/heightmap.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/heightmap.py
@@ -27,6 +27,7 @@ def terrain_to_heightmap(
     output_dir: str,
     model_name: str = "terrain",
     land_texture: Optional[Image.Image] = None,
+    osm_tex_size: Optional[float] = None,
 ) -> dict:
     """Convert a terrain elevation grid to a 16-bit PNG heightmap.
 
@@ -40,8 +41,12 @@ def terrain_to_heightmap(
         model_name: Gazebo model name for the terrain. Must be globally
             unique across all worlds (e.g. 'portsmouth_nh_harbor_terrain').
         land_texture: Optional PIL Image to use as land diffuse texture.
-            If provided, replaces the 16x16 placeholder and sets the SDF
-            texture size to match terrain dimensions for 1:1 mapping.
+            If provided, replaces the 16x16 placeholder. The SDF texture
+            size is set to ``osm_tex_size`` (max(size_x, size_y)) for
+            correct UV mapping on non-square heightmaps.
+        osm_tex_size: Texture tiling size in meters. Required when
+            ``land_texture`` is provided so the model SDF is written
+            with the correct ``<size>`` for 1:1 UV mapping.
 
     Returns:
         dict with keys needed for SDF generation:
@@ -109,6 +114,8 @@ def terrain_to_heightmap(
         "max_elevation": max_elev,
         "has_osm_texture": land_texture is not None,
     }
+    if osm_tex_size is not None:
+        heightmap_info["osm_tex_size"] = osm_tex_size
     _write_model_sdf(model_dir, heightmap_info)
 
     return heightmap_info
@@ -197,8 +204,8 @@ def _write_model_sdf(model_dir: str, info: dict):
 
     mn = info['model_name']
 
-    # Land texture <size>: use terrain dimensions for 1:1 mapping when
-    # an OSM-rasterized texture is present, otherwise tile at 10m.
+    # Land texture <size>: use osm_tex_size (max(size_x, size_y)) for
+    # correct UV mapping on non-square heightmaps, otherwise tile at 10m.
     if info.get("has_osm_texture"):
         land_tex_size = f"{info.get('osm_tex_size', info['size_x']):.1f}"
     else:

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_fetcher.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_fetcher.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Fetch OpenStreetMap building data via the Overpass API."""
+"""Fetch OpenStreetMap building and terrain feature data via the Overpass API."""
 
 import hashlib
 import json
@@ -52,26 +52,77 @@ class OsmBuilding:
 
 
 @dataclass
+class OsmLanduse:
+    """A landuse polygon from OpenStreetMap."""
+
+    geometry: ogr.Geometry  # Polygon in WGS84
+    landuse: str = ''  # e.g. residential, commercial, grass, forest
+
+
+@dataclass
+class OsmRoad:
+    """A road linestring from OpenStreetMap."""
+
+    geometry: ogr.Geometry  # LineString in WGS84
+    highway: str = ''  # e.g. secondary, residential, service, footway
+
+
+@dataclass
+class OsmParking:
+    """A parking area polygon from OpenStreetMap."""
+
+    geometry: ogr.Geometry  # Polygon in WGS84
+
+
+@dataclass
+class OsmNatural:
+    """A natural area polygon from OpenStreetMap."""
+
+    geometry: ogr.Geometry  # Polygon in WGS84
+    natural: str = ''  # e.g. wood, wetland, beach, scrub
+
+
+@dataclass
 class OsmFeatures:
     """Collection of features fetched from OpenStreetMap."""
 
     buildings: List[OsmBuilding] = field(default_factory=list)
+    landuse: List[OsmLanduse] = field(default_factory=list)
+    roads: List[OsmRoad] = field(default_factory=list)
+    parking: List[OsmParking] = field(default_factory=list)
+    natural: List[OsmNatural] = field(default_factory=list)
 
 
-def _cache_key(bbox: BoundingBox) -> str:
+def _cache_key(bbox: BoundingBox, terrain: bool = False) -> str:
     """Generate a deterministic cache key from bbox."""
-    s = f"osm:{bbox.south:.6f},{bbox.west:.6f},{bbox.north:.6f},{bbox.east:.6f}"
+    prefix = "osm_terrain" if terrain else "osm"
+    s = f"{prefix}:{bbox.south:.6f},{bbox.west:.6f},{bbox.north:.6f},{bbox.east:.6f}"
     return hashlib.md5(s.encode()).hexdigest()
 
 
-def _build_overpass_query(bbox: BoundingBox) -> str:
-    """Build Overpass QL query for buildings in the bounding box."""
+def _build_overpass_query(bbox: BoundingBox,
+                          fetch_terrain_features: bool = False) -> str:
+    """Build Overpass QL query for buildings (and terrain features) in bbox."""
     b = f"{bbox.south},{bbox.west},{bbox.north},{bbox.east}"
+    if not fetch_terrain_features:
+        return (
+            "[out:json][timeout:120];\n"
+            "(\n"
+            f'  way["building"]({b});\n'
+            f'  relation["building"]({b});\n'
+            ");\n"
+            "out geom;\n"
+        )
+    # Combined query: buildings + landuse + roads + parking + natural
     return (
         "[out:json][timeout:120];\n"
         "(\n"
         f'  way["building"]({b});\n'
         f'  relation["building"]({b});\n'
+        f'  way["landuse"]({b});\n'
+        f'  way["highway"]({b});\n'
+        f'  way["amenity"="parking"]({b});\n'
+        f'  way["natural"]({b});\n'
         ");\n"
         "out geom;\n"
     )
@@ -161,32 +212,96 @@ def _parse_element(element: dict) -> Optional[OsmBuilding]:
     )
 
 
+def _coords_to_linestring(coords: list) -> Optional[ogr.Geometry]:
+    """Convert a list of {'lat': ..., 'lon': ...} dicts to an OGR LineString.
+
+    Returns None if fewer than 2 points.
+    """
+    if len(coords) < 2:
+        return None
+    line = ogr.Geometry(ogr.wkbLineString)
+    for pt in coords:
+        line.AddPoint(pt["lon"], pt["lat"])
+    return line
+
+
+def _parse_terrain_element(element: dict, features: OsmFeatures):
+    """Parse a terrain-related element (landuse, road, parking, natural)."""
+    tags = element.get("tags", {})
+    geom_coords = element.get("geometry")
+    if not geom_coords:
+        return
+
+    # Landuse polygons
+    if "landuse" in tags and "building" not in tags:
+        polygon = _coords_to_polygon(geom_coords)
+        if polygon is not None and polygon.IsValid():
+            features.landuse.append(OsmLanduse(
+                geometry=polygon,
+                landuse=tags.get("landuse", ""),
+            ))
+        return
+
+    # Roads (linestrings)
+    if "highway" in tags:
+        linestring = _coords_to_linestring(geom_coords)
+        if linestring is not None:
+            features.roads.append(OsmRoad(
+                geometry=linestring,
+                highway=tags.get("highway", ""),
+            ))
+        return
+
+    # Parking areas
+    if tags.get("amenity") == "parking":
+        polygon = _coords_to_polygon(geom_coords)
+        if polygon is not None and polygon.IsValid():
+            features.parking.append(OsmParking(geometry=polygon))
+        return
+
+    # Natural areas
+    if "natural" in tags and "building" not in tags:
+        polygon = _coords_to_polygon(geom_coords)
+        if polygon is not None and polygon.IsValid():
+            features.natural.append(OsmNatural(
+                geometry=polygon,
+                natural=tags.get("natural", ""),
+            ))
+        return
+
+
 def fetch_osm_features(
     bbox: BoundingBox,
     cache_dir: Optional[str] = None,
+    fetch_terrain_features: bool = False,
 ) -> OsmFeatures:
-    """Fetch OSM building features for a bounding box via Overpass API.
+    """Fetch OSM features for a bounding box via Overpass API.
 
     Args:
         bbox: Geographic bounding box in WGS84 degrees.
         cache_dir: Directory to cache downloaded data. Defaults to
             ~/.cache/marine_charts_to_gazebo_world/.
+        fetch_terrain_features: If True, also fetch landuse, roads,
+            parking, and natural areas for terrain texturing.
 
     Returns:
-        OsmFeatures with parsed buildings.
+        OsmFeatures with parsed buildings (and terrain features if requested).
     """
     if cache_dir is None:
         cache_dir = _DEFAULT_CACHE_DIR
     os.makedirs(cache_dir, exist_ok=True)
 
-    cache_file = os.path.join(cache_dir, f"osm_{_cache_key(bbox)}.json")
+    cache_file = os.path.join(
+        cache_dir,
+        f"osm_{_cache_key(bbox, terrain=fetch_terrain_features)}.json",
+    )
 
     if os.path.exists(cache_file):
         logger.info("Using cached OSM data: %s", cache_file)
         with open(cache_file) as f:
             data = json.load(f)
     else:
-        query = _build_overpass_query(bbox)
+        query = _build_overpass_query(bbox, fetch_terrain_features)
         logger.info("Querying Overpass API...")
         response = requests.get(
             _OVERPASS_URL,
@@ -218,5 +333,7 @@ def fetch_osm_features(
         building = _parse_element(element)
         if building is not None:
             features.buildings.append(building)
+        if fetch_terrain_features:
+            _parse_terrain_element(element, features)
 
     return features

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_fetcher.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_fetcher.py
@@ -77,6 +77,8 @@ class OsmRoad:
 
     geometry: ogr.Geometry  # LineString in WGS84
     highway: str = ''  # e.g. secondary, residential, service, footway
+    bridge: bool = False  # True if bridge=yes tag is present
+    layer: int = 0  # from layer= tag (bridges are typically layer=1)
 
 
 @dataclass
@@ -100,6 +102,7 @@ class OsmManMade:
 
     geometry: ogr.Geometry  # Polygon or LineString in WGS84
     man_made: str = ''  # e.g. pier, quay, breakwater, groyne
+    floating: Optional[bool] = None  # True/False from floating= tag, None if absent
 
 
 @dataclass
@@ -255,6 +258,35 @@ def _parse_terrain_element(element: dict, features: OsmFeatures):
     if not geom_coords:
         return
 
+    # Marine infrastructure takes priority (piers may also have landuse tags)
+    man_made_type = tags.get("man_made", "")
+    if man_made_type in ("pier", "quay", "breakwater", "groyne"):
+        floating_tag = tags.get("floating")
+        floating = None
+        if floating_tag == "yes":
+            floating = True
+        elif floating_tag == "no":
+            floating = False
+        # Only treat as polygon if the way is actually closed (first == last node)
+        is_closed = (len(geom_coords) >= 4
+                     and geom_coords[0]["lat"] == geom_coords[-1]["lat"]
+                     and geom_coords[0]["lon"] == geom_coords[-1]["lon"])
+        if is_closed:
+            polygon = _coords_to_polygon(geom_coords)
+            if polygon is not None and polygon.IsValid():
+                features.man_made.append(OsmManMade(
+                    geometry=polygon, man_made=man_made_type,
+                    floating=floating,
+                ))
+                return
+        linestring = _coords_to_linestring(geom_coords)
+        if linestring is not None:
+            features.man_made.append(OsmManMade(
+                geometry=linestring, man_made=man_made_type,
+                floating=floating,
+            ))
+        return
+
     # Landuse polygons
     if "landuse" in tags and "building" not in tags:
         polygon = _coords_to_polygon(geom_coords)
@@ -269,9 +301,16 @@ def _parse_terrain_element(element: dict, features: OsmFeatures):
     if "highway" in tags:
         linestring = _coords_to_linestring(geom_coords)
         if linestring is not None:
+            layer_val = 0
+            try:
+                layer_val = int(tags.get("layer", "0"))
+            except ValueError:
+                pass
             features.roads.append(OsmRoad(
                 geometry=linestring,
                 highway=tags.get("highway", ""),
+                bridge=tags.get("bridge") == "yes",
+                layer=layer_val,
             ))
         return
 
@@ -290,23 +329,6 @@ def _parse_terrain_element(element: dict, features: OsmFeatures):
                 geometry=polygon,
                 natural=tags.get("natural", ""),
             ))
-        return
-
-    # Marine infrastructure (man_made: pier, quay, breakwater, groyne)
-    man_made_type = tags.get("man_made", "")
-    if man_made_type in ("pier", "quay", "breakwater", "groyne"):
-        # Try polygon first, fall back to linestring
-        polygon = _coords_to_polygon(geom_coords)
-        if polygon is not None and polygon.IsValid():
-            features.man_made.append(OsmManMade(
-                geometry=polygon, man_made=man_made_type,
-            ))
-        else:
-            linestring = _coords_to_linestring(geom_coords)
-            if linestring is not None:
-                features.man_made.append(OsmManMade(
-                    geometry=linestring, man_made=man_made_type,
-                ))
         return
 
     # Waterway=dock (water basin) — store as natural water area

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_fetcher.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_fetcher.py
@@ -22,6 +22,8 @@ import tempfile
 from dataclasses import dataclass, field
 from typing import List, Optional
 
+import time
+
 import requests
 from osgeo import ogr
 
@@ -31,7 +33,17 @@ ogr.UseExceptions()
 
 logger = logging.getLogger(__name__)
 
-_OVERPASS_URL = "https://overpass-api.de/api/interpreter"
+# Overpass API endpoints, tried in order.  The primary is the main public
+# instance; the others are community mirrors used as fallbacks.
+_OVERPASS_ENDPOINTS = [
+    "https://overpass-api.de/api/interpreter",
+    "https://overpass.kumi.systems/api/interpreter",
+    "https://maps.mail.ru/osm/tools/overpass/api/interpreter",
+]
+
+# Retry parameters
+_MAX_RETRIES = 3
+_RETRY_BACKOFF_BASE = 5  # seconds; actual wait = base * 2^attempt
 
 _DEFAULT_CACHE_DIR = os.path.join(
     os.environ.get("XDG_CACHE_HOME", os.path.expanduser("~/.cache")),
@@ -270,6 +282,43 @@ def _parse_terrain_element(element: dict, features: OsmFeatures):
         return
 
 
+def _fetch_with_retries(query: str) -> dict:
+    """Fetch Overpass data, retrying across endpoints with backoff.
+
+    Tries each endpoint up to ``_MAX_RETRIES`` times with exponential
+    backoff before moving to the next endpoint.  Raises the last
+    encountered exception if all endpoints and retries are exhausted.
+    """
+    last_exc = None
+    for endpoint in _OVERPASS_ENDPOINTS:
+        for attempt in range(_MAX_RETRIES):
+            try:
+                logger.info(
+                    "Querying %s (attempt %d/%d)...",
+                    endpoint, attempt + 1, _MAX_RETRIES,
+                )
+                response = requests.get(
+                    endpoint,
+                    params={"data": query},
+                    timeout=(30, 180),
+                )
+                response.raise_for_status()
+                return response.json()
+            except (requests.RequestException, ValueError) as exc:
+                last_exc = exc
+                wait = _RETRY_BACKOFF_BASE * (2 ** attempt)
+                logger.warning(
+                    "%s attempt %d failed: %s  Retrying in %ds...",
+                    endpoint, attempt + 1, exc, wait,
+                )
+                time.sleep(wait)
+        logger.warning(
+            "All %d retries exhausted for %s, trying next endpoint...",
+            _MAX_RETRIES, endpoint,
+        )
+    raise last_exc  # type: ignore[misc]
+
+
 def fetch_osm_features(
     bbox: BoundingBox,
     cache_dir: Optional[str] = None,
@@ -302,14 +351,7 @@ def fetch_osm_features(
             data = json.load(f)
     else:
         query = _build_overpass_query(bbox, fetch_terrain_features)
-        logger.info("Querying Overpass API...")
-        response = requests.get(
-            _OVERPASS_URL,
-            params={"data": query},
-            timeout=(30, 180),
-        )
-        response.raise_for_status()
-        data = response.json()
+        data = _fetch_with_retries(query)
 
         # Write cache atomically
         fd, tmp_path = tempfile.mkstemp(

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_fetcher.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_fetcher.py
@@ -95,6 +95,14 @@ class OsmNatural:
 
 
 @dataclass
+class OsmManMade:
+    """A man-made marine infrastructure feature from OpenStreetMap."""
+
+    geometry: ogr.Geometry  # Polygon or LineString in WGS84
+    man_made: str = ''  # e.g. pier, quay, breakwater, groyne
+
+
+@dataclass
 class OsmFeatures:
     """Collection of features fetched from OpenStreetMap."""
 
@@ -103,11 +111,12 @@ class OsmFeatures:
     roads: List[OsmRoad] = field(default_factory=list)
     parking: List[OsmParking] = field(default_factory=list)
     natural: List[OsmNatural] = field(default_factory=list)
+    man_made: List[OsmManMade] = field(default_factory=list)
 
 
 def _cache_key(bbox: BoundingBox, terrain: bool = False) -> str:
     """Generate a deterministic cache key from bbox."""
-    prefix = "osm_terrain" if terrain else "osm"
+    prefix = "osm_terrain_v2" if terrain else "osm"
     s = f"{prefix}:{bbox.south:.6f},{bbox.west:.6f},{bbox.north:.6f},{bbox.east:.6f}"
     return hashlib.md5(s.encode()).hexdigest()
 
@@ -125,7 +134,7 @@ def _build_overpass_query(bbox: BoundingBox,
             ");\n"
             "out geom;\n"
         )
-    # Combined query: buildings + landuse + roads + parking + natural
+    # Combined query: buildings + landuse + roads + parking + natural + marine
     return (
         "[out:json][timeout:120];\n"
         "(\n"
@@ -135,6 +144,8 @@ def _build_overpass_query(bbox: BoundingBox,
         f'  way["highway"]({b});\n'
         f'  way["amenity"="parking"]({b});\n'
         f'  way["natural"]({b});\n'
+        f'  way["man_made"~"pier|quay|breakwater|groyne"]({b});\n'
+        f'  way["waterway"="dock"]({b});\n'
         ");\n"
         "out geom;\n"
     )
@@ -278,6 +289,32 @@ def _parse_terrain_element(element: dict, features: OsmFeatures):
             features.natural.append(OsmNatural(
                 geometry=polygon,
                 natural=tags.get("natural", ""),
+            ))
+        return
+
+    # Marine infrastructure (man_made: pier, quay, breakwater, groyne)
+    man_made_type = tags.get("man_made", "")
+    if man_made_type in ("pier", "quay", "breakwater", "groyne"):
+        # Try polygon first, fall back to linestring
+        polygon = _coords_to_polygon(geom_coords)
+        if polygon is not None and polygon.IsValid():
+            features.man_made.append(OsmManMade(
+                geometry=polygon, man_made=man_made_type,
+            ))
+        else:
+            linestring = _coords_to_linestring(geom_coords)
+            if linestring is not None:
+                features.man_made.append(OsmManMade(
+                    geometry=linestring, man_made=man_made_type,
+                ))
+        return
+
+    # Waterway=dock (water basin) — store as natural water area
+    if tags.get("waterway") == "dock":
+        polygon = _coords_to_polygon(geom_coords)
+        if polygon is not None and polygon.IsValid():
+            features.natural.append(OsmNatural(
+                geometry=polygon, natural="water",
             ))
         return
 

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_matcher.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_matcher.py
@@ -64,6 +64,7 @@ def _iou(geom_a: ogr.Geometry, geom_b: ogr.Geometry) -> float:
 def match_and_enrich(
     s57_features: S57Features,
     osm_features: OsmFeatures,
+    add_unmatched: bool = True,
 ) -> tuple:
     """Match S57 buildings to OSM buildings and enrich with OSM data.
 
@@ -71,12 +72,16 @@ def match_and_enrich(
     and IoU. When matched, copies OSM height, material, and colour onto
     the S57 Building dataclass, and replaces the footprint polygon.
 
-    Unmatched OSM buildings are converted to S57 Building objects and
-    appended to the buildings list.
+    When *add_unmatched* is True (the default), unmatched OSM buildings
+    are converted to S57 Building objects and appended to the buildings
+    list.
 
     Args:
         s57_features: S57Features with buildings to enrich.
         osm_features: OsmFeatures with OSM buildings to match against.
+        add_unmatched: If True, add unmatched OSM buildings as new
+            S57 Building objects. Set False to only enrich existing
+            S57 buildings without adding new ones.
 
     Returns:
         Tuple of (enriched S57Features, number of matched buildings,
@@ -133,6 +138,8 @@ def match_and_enrich(
 
     # Add unmatched OSM buildings as new Building objects
     n_added = 0
+    if not add_unmatched:
+        return s57_features, n_matched, n_added
     for idx, osm_building in enumerate(osm_features.buildings):
         if idx in matched_osm_indices:
             continue

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_matcher.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_matcher.py
@@ -166,15 +166,18 @@ def match_and_enrich(
 
 # --- Pier matching ---
 
-# Maximum centroid distance for pier matching (~100m at mid-latitudes).
-_MAX_PIER_CENTROID_DISTANCE_DEG = 0.0009
+# Maximum centroid distance for pier matching (~400m at mid-latitudes).
+# Piers are large features; S57 linestrings may be individual edges
+# whose centroids are far from the OSM polygon centroid.
+_MAX_PIER_CENTROID_DISTANCE_DEG = 0.004
 
 # Buffer around S57 linestring (~2m in degrees) to create an area for overlap.
 _PIER_LINE_BUFFER_DEG = 0.00002
 
 # Minimum fraction of the buffered S57 line that must fall inside the OSM
-# polygon to accept a match.
-_MIN_PIER_OVERLAP = 0.3
+# polygon to accept a match.  S57 pier lines run along polygon edges,
+# so only ~half the buffer falls inside — 0.1 captures real matches.
+_MIN_PIER_OVERLAP = 0.1
 
 
 def _line_polygon_overlap(line: ogr.Geometry, polygon: ogr.Geometry) -> float:

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_matcher.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_matcher.py
@@ -166,35 +166,14 @@ def match_and_enrich(
 
 # --- Pier matching ---
 
-# Maximum centroid distance for pier matching (~400m at mid-latitudes).
-# Piers are large features; S57 linestrings may be individual edges
-# whose centroids are far from the OSM polygon centroid.
-_MAX_PIER_CENTROID_DISTANCE_DEG = 0.004
+# Maximum distance (degrees) between an S57 pier linestring and an OSM
+# pier polygon to consider them the same physical feature.
+# ~5m ≈ 0.00005 degrees at mid-latitudes.
+_MAX_PIER_DISTANCE_DEG = 0.00005
 
-# Buffer around S57 linestring (~2m in degrees) to create an area for overlap.
-_PIER_LINE_BUFFER_DEG = 0.00002
-
-# Minimum fraction of the buffered S57 line that must fall inside the OSM
-# polygon to accept a match.  S57 pier lines run along polygon edges,
-# so only ~half the buffer falls inside — 0.1 captures real matches.
-_MIN_PIER_OVERLAP = 0.1
-
-
-def _line_polygon_overlap(line: ogr.Geometry, polygon: ogr.Geometry) -> float:
-    """Fraction of a buffered linestring that overlaps with a polygon."""
-    try:
-        buffered = line.Buffer(_PIER_LINE_BUFFER_DEG)
-        if buffered is None or buffered.IsEmpty():
-            return 0.0
-        buffered_area = buffered.GetArea()
-        if buffered_area == 0.0:
-            return 0.0
-        intersection = buffered.Intersection(polygon)
-        if intersection is None or intersection.IsEmpty():
-            return 0.0
-        return intersection.GetArea() / buffered_area
-    except Exception:
-        return 0.0
+# Coarse centroid filter to avoid expensive Distance() calls.
+# ~500m at mid-latitudes.
+_MAX_PIER_CENTROID_DISTANCE_DEG = 0.005
 
 
 def match_piers(
@@ -204,10 +183,15 @@ def match_piers(
 ) -> tuple:
     """Match S57 SLCONS piers to OSM man_made=pier polygons.
 
-    For each S57 SLCONS with catslc=4 (pier/jetty), finds the best OSM
-    pier polygon match using centroid proximity and buffered-line overlap.
-    When matched, stores the OSM polygon as ``osm_geometry`` on the
-    ShoreCon for polygon rendering.
+    S57 piers are typically linestrings that run along the edges of the
+    physical pier.  Multiple linestrings may represent the same pier.
+    OSM has polygon outlines for the full pier footprint.
+
+    This function uses **proximity matching**: an S57 pier linestring is
+    matched to an OSM pier polygon when the geometry distance is less
+    than ~5m.  All matched linestrings get the OSM polygon stored as
+    ``osm_geometry``; the renderer uses that polygon instead of wall
+    segments.
 
     When *add_unmatched* is True, unmatched OSM pier polygons are added
     as new ShoreCon objects with ``osm_only=True``.
@@ -235,32 +219,38 @@ def match_piers(
     for sc in s57_features.shore_constructions:
         if sc.catslc != 4:
             continue
-        # Only match linestring S57 piers (polygons are already good)
+        # Only match linestring S57 piers (polygons already render fine)
         geom_type = sc.geometry.GetGeometryType() & 0xFF
         if geom_type not in (2, 5, 7):  # LineString, MultiLineString, Collection
             continue
 
-        best_overlap = 0.0
+        best_dist = _MAX_PIER_DISTANCE_DEG
         best_osm_idx = -1
         best_osm_geom = None
 
         for osm_idx, osm_mm in osm_piers:
-            dist = _centroid_distance_deg(sc.geometry, osm_mm.geometry)
-            if dist > _MAX_PIER_CENTROID_DISTANCE_DEG:
+            # Coarse centroid filter
+            cdist = _centroid_distance_deg(sc.geometry, osm_mm.geometry)
+            if cdist > _MAX_PIER_CENTROID_DISTANCE_DEG:
                 continue
 
-            overlap = _line_polygon_overlap(sc.geometry, osm_mm.geometry)
-            if overlap > best_overlap:
-                best_overlap = overlap
+            try:
+                dist = sc.geometry.Distance(osm_mm.geometry)
+            except Exception:
+                continue
+
+            if dist < best_dist:
+                best_dist = dist
                 best_osm_idx = osm_idx
                 best_osm_geom = osm_mm.geometry
 
-        if best_osm_geom is not None and best_overlap >= _MIN_PIER_OVERLAP:
+        if best_osm_geom is not None:
             matched_osm_indices.add(best_osm_idx)
             sc.osm_geometry = best_osm_geom.Clone()
             n_matched += 1
             logger.debug(
-                "Matched S57 pier to OSM pier (overlap=%.2f)", best_overlap,
+                "Matched S57 pier to OSM pier (dist=%.6f deg)",
+                best_dist,
             )
 
     # Add unmatched OSM piers as new ShoreCon objects

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_matcher.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_matcher.py
@@ -181,24 +181,20 @@ def match_piers(
     osm_features: OsmFeatures,
     add_unmatched: bool = True,
 ) -> tuple:
-    """Match S57 SLCONS piers to OSM man_made=pier polygons.
+    """Replace S57 SLCONS pier features with OSM man_made=pier polygons.
 
-    S57 piers are typically linestrings that run along the edges of the
-    physical pier.  Multiple linestrings may represent the same pier.
-    OSM has polygon outlines for the full pier footprint.
-
-    This function uses **proximity matching**: an S57 pier linestring is
-    matched to an OSM pier polygon when the geometry distance is less
-    than ~5m.  All matched linestrings get the OSM polygon stored as
-    ``osm_geometry``; the renderer uses that polygon instead of wall
-    segments.
+    S57 represents piers as a combination of polygon features and edge
+    linestrings.  OSM has single polygon outlines for each pier.
+    This function finds all S57 pier features (catslc=4) within ~5m of
+    each OSM pier polygon and replaces them with a single ShoreCon
+    carrying the OSM polygon.
 
     When *add_unmatched* is True, unmatched OSM pier polygons are added
-    as new ShoreCon objects with ``osm_only=True``.
+    as new ShoreCon objects.
 
     Returns:
-        Tuple of (enriched S57Features, n_matched, n_added, set of
-        matched OSM man_made indices).
+        Tuple of (enriched S57Features, n_s57_replaced, n_osm_added,
+        set of matched OSM man_made indices).
     """
     # Collect OSM pier polygons (with their index into osm_features.man_made)
     osm_piers = []
@@ -214,21 +210,20 @@ def match_piers(
         return s57_features, 0, 0, set()
 
     matched_osm_indices = set()
-    n_matched = 0
+    suppress_sc_indices = set()  # S57 shore_constructions indices to remove
+    replacements = []  # OSM polygons to add as replacements
+    n_replaced = 0
 
-    for sc in s57_features.shore_constructions:
-        if sc.catslc != 4:
-            continue
-        # Only match linestring S57 piers (polygons already render fine)
-        geom_type = sc.geometry.GetGeometryType() & 0xFF
-        if geom_type not in (2, 5, 7):  # LineString, MultiLineString, Collection
-            continue
+    # For each OSM pier polygon, find ALL nearby S57 pier features
+    for osm_idx, osm_mm in osm_piers:
+        matched_any = False
 
-        best_dist = _MAX_PIER_DISTANCE_DEG
-        best_osm_idx = -1
-        best_osm_geom = None
+        for sc_idx, sc in enumerate(s57_features.shore_constructions):
+            if sc.catslc != 4:
+                continue
+            if sc_idx in suppress_sc_indices:
+                continue
 
-        for osm_idx, osm_mm in osm_piers:
             # Coarse centroid filter
             cdist = _centroid_distance_deg(sc.geometry, osm_mm.geometry)
             if cdist > _MAX_PIER_CENTROID_DISTANCE_DEG:
@@ -239,19 +234,30 @@ def match_piers(
             except Exception:
                 continue
 
-            if dist < best_dist:
-                best_dist = dist
-                best_osm_idx = osm_idx
-                best_osm_geom = osm_mm.geometry
+            if dist < _MAX_PIER_DISTANCE_DEG:
+                suppress_sc_indices.add(sc_idx)
+                matched_any = True
+                n_replaced += 1
+                logger.debug(
+                    "Suppressing S57 pier [%d] for OSM pier (dist=%.6f)",
+                    sc_idx, dist,
+                )
 
-        if best_osm_geom is not None:
-            matched_osm_indices.add(best_osm_idx)
-            sc.osm_geometry = best_osm_geom.Clone()
-            n_matched += 1
-            logger.debug(
-                "Matched S57 pier to OSM pier (dist=%.6f deg)",
-                best_dist,
-            )
+        if matched_any:
+            matched_osm_indices.add(osm_idx)
+            replacements.append(ShoreCon(
+                geometry=osm_mm.geometry.Clone(),
+                catslc=4,
+                osm_only=True,
+            ))
+
+    # Remove suppressed S57 features and add OSM replacements
+    if suppress_sc_indices:
+        s57_features.shore_constructions = [
+            sc for idx, sc in enumerate(s57_features.shore_constructions)
+            if idx not in suppress_sc_indices
+        ]
+    s57_features.shore_constructions.extend(replacements)
 
     # Add unmatched OSM piers as new ShoreCon objects
     n_added = 0
@@ -266,4 +272,4 @@ def match_piers(
             ))
             n_added += 1
 
-    return s57_features, n_matched, n_added, matched_osm_indices
+    return s57_features, n_replaced, n_added, matched_osm_indices

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_matcher.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_matcher.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Match S57 buildings to OSM buildings and enrich with OSM metadata."""
+"""Match S57 features to OSM features and enrich with OSM metadata."""
 
 import logging
 import math
@@ -20,7 +20,7 @@ import math
 from osgeo import ogr
 
 from .osm_fetcher import OsmFeatures
-from .s57_reader import Building, S57Features
+from .s57_reader import Building, S57Features, ShoreCon
 
 ogr.UseExceptions()
 
@@ -162,3 +162,115 @@ def match_and_enrich(
         n_added += 1
 
     return s57_features, n_matched, n_added
+
+
+# --- Pier matching ---
+
+# Maximum centroid distance for pier matching (~100m at mid-latitudes).
+_MAX_PIER_CENTROID_DISTANCE_DEG = 0.0009
+
+# Buffer around S57 linestring (~2m in degrees) to create an area for overlap.
+_PIER_LINE_BUFFER_DEG = 0.00002
+
+# Minimum fraction of the buffered S57 line that must fall inside the OSM
+# polygon to accept a match.
+_MIN_PIER_OVERLAP = 0.3
+
+
+def _line_polygon_overlap(line: ogr.Geometry, polygon: ogr.Geometry) -> float:
+    """Fraction of a buffered linestring that overlaps with a polygon."""
+    try:
+        buffered = line.Buffer(_PIER_LINE_BUFFER_DEG)
+        if buffered is None or buffered.IsEmpty():
+            return 0.0
+        buffered_area = buffered.GetArea()
+        if buffered_area == 0.0:
+            return 0.0
+        intersection = buffered.Intersection(polygon)
+        if intersection is None or intersection.IsEmpty():
+            return 0.0
+        return intersection.GetArea() / buffered_area
+    except Exception:
+        return 0.0
+
+
+def match_piers(
+    s57_features: S57Features,
+    osm_features: OsmFeatures,
+    add_unmatched: bool = True,
+) -> tuple:
+    """Match S57 SLCONS piers to OSM man_made=pier polygons.
+
+    For each S57 SLCONS with catslc=4 (pier/jetty), finds the best OSM
+    pier polygon match using centroid proximity and buffered-line overlap.
+    When matched, stores the OSM polygon as ``osm_geometry`` on the
+    ShoreCon for polygon rendering.
+
+    When *add_unmatched* is True, unmatched OSM pier polygons are added
+    as new ShoreCon objects with ``osm_only=True``.
+
+    Returns:
+        Tuple of (enriched S57Features, n_matched, n_added, set of
+        matched OSM man_made indices).
+    """
+    # Collect OSM pier polygons (with their index into osm_features.man_made)
+    osm_piers = []
+    for idx, mm in enumerate(osm_features.man_made):
+        if mm.man_made != 'pier':
+            continue
+        geom_type = mm.geometry.GetGeometryType() & 0xFF
+        if geom_type not in (3, 6):  # only Polygon / MultiPolygon
+            continue
+        osm_piers.append((idx, mm))
+
+    if not osm_piers:
+        return s57_features, 0, 0, set()
+
+    matched_osm_indices = set()
+    n_matched = 0
+
+    for sc in s57_features.shore_constructions:
+        if sc.catslc != 4:
+            continue
+        # Only match linestring S57 piers (polygons are already good)
+        geom_type = sc.geometry.GetGeometryType() & 0xFF
+        if geom_type not in (2, 5, 7):  # LineString, MultiLineString, Collection
+            continue
+
+        best_overlap = 0.0
+        best_osm_idx = -1
+        best_osm_geom = None
+
+        for osm_idx, osm_mm in osm_piers:
+            dist = _centroid_distance_deg(sc.geometry, osm_mm.geometry)
+            if dist > _MAX_PIER_CENTROID_DISTANCE_DEG:
+                continue
+
+            overlap = _line_polygon_overlap(sc.geometry, osm_mm.geometry)
+            if overlap > best_overlap:
+                best_overlap = overlap
+                best_osm_idx = osm_idx
+                best_osm_geom = osm_mm.geometry
+
+        if best_osm_geom is not None and best_overlap >= _MIN_PIER_OVERLAP:
+            matched_osm_indices.add(best_osm_idx)
+            sc.osm_geometry = best_osm_geom.Clone()
+            n_matched += 1
+            logger.debug(
+                "Matched S57 pier to OSM pier (overlap=%.2f)", best_overlap,
+            )
+
+    # Add unmatched OSM piers as new ShoreCon objects
+    n_added = 0
+    if add_unmatched:
+        for osm_idx, osm_mm in osm_piers:
+            if osm_idx in matched_osm_indices:
+                continue
+            s57_features.shore_constructions.append(ShoreCon(
+                geometry=osm_mm.geometry.Clone(),
+                catslc=4,
+                osm_only=True,
+            ))
+            n_added += 1
+
+    return s57_features, n_matched, n_added, matched_osm_indices

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_matcher.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_matcher.py
@@ -157,6 +157,7 @@ def match_and_enrich(
             osm_height=osm_height,
             osm_material=osm_building.material,
             osm_colour=osm_building.colour,
+            osm_only=True,
         ))
         n_added += 1
 

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_texture.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_texture.py
@@ -1,0 +1,223 @@
+# Copyright 2025 Roland Arsenault
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rasterize OSM terrain features onto a PIL Image for heightmap texturing."""
+
+import logging
+from typing import Optional
+
+import numpy as np
+from PIL import Image, ImageDraw
+
+from .coordinates import latlon_to_enu_array
+from .osm_fetcher import OsmFeatures
+
+logger = logging.getLogger(__name__)
+
+# Base land color (muted green-brown, matching the original placeholder)
+LAND_BASE = (120, 140, 95)
+
+# Landuse colors by type
+_LANDUSE_COLORS = {
+    "grass": (100, 160, 80),
+    "meadow": (110, 165, 85),
+    "recreation_ground": (100, 160, 80),
+    "residential": (175, 170, 160),
+    "commercial": (200, 190, 170),
+    "retail": (200, 185, 165),
+    "industrial": (185, 180, 175),
+    "farmland": (180, 195, 140),
+    "farmyard": (185, 180, 150),
+    "forest": (70, 120, 55),
+    "cemetery": (130, 155, 110),
+    "military": (160, 155, 140),
+}
+
+# Natural area colors by type
+_NATURAL_COLORS = {
+    "wood": (60, 110, 50),
+    "scrub": (85, 130, 65),
+    "heath": (130, 150, 100),
+    "grassland": (110, 165, 85),
+    "wetland": (80, 140, 130),
+    "marsh": (80, 140, 130),
+    "beach": (210, 200, 170),
+    "sand": (210, 200, 170),
+    "bare_rock": (170, 165, 155),
+    "water": (100, 140, 180),
+}
+
+# Parking color
+_PARKING_COLOR = (130, 130, 130)
+
+# Road colors and widths (meters) by highway type
+_ROAD_STYLES = {
+    "motorway": {"color": (140, 140, 140), "width": 12.0},
+    "trunk": {"color": (140, 140, 140), "width": 10.0},
+    "primary": {"color": (150, 150, 145), "width": 9.0},
+    "secondary": {"color": (155, 155, 150), "width": 8.0},
+    "tertiary": {"color": (160, 160, 155), "width": 7.0},
+    "residential": {"color": (165, 165, 160), "width": 6.0},
+    "unclassified": {"color": (165, 165, 160), "width": 5.0},
+    "service": {"color": (170, 170, 165), "width": 4.0},
+    "track": {"color": (175, 170, 155), "width": 3.0},
+    "footway": {"color": (180, 175, 165), "width": 1.5},
+    "path": {"color": (180, 175, 165), "width": 1.5},
+    "cycleway": {"color": (180, 175, 165), "width": 2.0},
+    "steps": {"color": (175, 170, 160), "width": 1.5},
+}
+_DEFAULT_ROAD_STYLE = {"color": (170, 170, 165), "width": 4.0}
+
+
+def _latlon_to_pixel(lats, lons, ref_lat, ref_lon, size_x, size_y, grid_size):
+    """Convert lat/lon arrays to pixel coordinates.
+
+    Args:
+        lats: numpy array of latitudes.
+        lons: numpy array of longitudes.
+        ref_lat: Reference latitude (terrain center).
+        ref_lon: Reference longitude (terrain center).
+        size_x: Terrain width in meters.
+        size_y: Terrain height in meters.
+        grid_size: Image size in pixels.
+
+    Returns:
+        List of (px, py) tuples suitable for PIL drawing.
+    """
+    east, north = latlon_to_enu_array(
+        np.asarray(lats, dtype=np.float64),
+        np.asarray(lons, dtype=np.float64),
+        ref_lat, ref_lon,
+    )
+    # ENU origin is at center; pixels go from 0 to grid_size-1
+    px = (east + size_x / 2) / size_x * (grid_size - 1)
+    py = (grid_size - 1) - (north + size_y / 2) / size_y * (grid_size - 1)
+    return list(zip(px.tolist(), py.tolist()))
+
+
+def _geometry_to_pixel_coords(geom, ref_lat, ref_lon,
+                              size_x, size_y, grid_size):
+    """Extract coordinates from an OGR geometry and convert to pixels.
+
+    For polygons, returns the exterior ring coordinates.
+    For linestrings, returns the point coordinates.
+    """
+    geom_type = geom.GetGeometryType() & 0xFF
+
+    if geom_type == 2:  # LineString
+        lats = [geom.GetY(i) for i in range(geom.GetPointCount())]
+        lons = [geom.GetX(i) for i in range(geom.GetPointCount())]
+        return _latlon_to_pixel(lats, lons, ref_lat, ref_lon,
+                                size_x, size_y, grid_size)
+
+    if geom_type == 3:  # Polygon
+        ring = geom.GetGeometryRef(0)  # exterior ring
+        if ring is None:
+            return []
+        lats = [ring.GetY(i) for i in range(ring.GetPointCount())]
+        lons = [ring.GetX(i) for i in range(ring.GetPointCount())]
+        return _latlon_to_pixel(lats, lons, ref_lat, ref_lon,
+                                size_x, size_y, grid_size)
+
+    return []
+
+
+def rasterize_osm_texture(
+    osm_features: OsmFeatures,
+    terrain_info: dict,
+    grid_size: int,
+    ref_lat: float,
+    ref_lon: float,
+    terrain: Optional[np.ndarray] = None,
+) -> Image.Image:
+    """Rasterize OSM features onto a texture image for heightmap land areas.
+
+    Renders features back-to-front:
+    1. Base land color
+    2. Landuse polygons
+    3. Natural area polygons
+    4. Parking polygons
+    5. Roads with appropriate widths
+
+    Only pixels above sea level (elevation > 0) are rendered when terrain
+    data is provided.
+
+    Args:
+        osm_features: Parsed OSM features with landuse, roads, parking, natural.
+        terrain_info: dict from build_terrain() with size_x, size_y.
+        grid_size: Image dimensions (grid_size x grid_size pixels).
+        ref_lat: Reference latitude for coordinate conversion.
+        ref_lon: Reference longitude for coordinate conversion.
+        terrain: Optional terrain elevation array for water masking.
+
+    Returns:
+        PIL Image (RGB) of the rasterized texture.
+    """
+    size_x = terrain_info["size_x"]
+    size_y = terrain_info["size_y"]
+
+    # Start with base land color
+    img = Image.new("RGB", (grid_size, grid_size), LAND_BASE)
+    draw = ImageDraw.Draw(img)
+
+    # Layer 1: Landuse polygons
+    for lu in osm_features.landuse:
+        color = _LANDUSE_COLORS.get(lu.landuse)
+        if color is None:
+            continue
+        coords = _geometry_to_pixel_coords(
+            lu.geometry, ref_lat, ref_lon, size_x, size_y, grid_size)
+        if len(coords) >= 3:
+            draw.polygon(coords, fill=color)
+
+    # Layer 2: Natural polygons
+    for nat in osm_features.natural:
+        color = _NATURAL_COLORS.get(nat.natural)
+        if color is None:
+            continue
+        coords = _geometry_to_pixel_coords(
+            nat.geometry, ref_lat, ref_lon, size_x, size_y, grid_size)
+        if len(coords) >= 3:
+            draw.polygon(coords, fill=color)
+
+    # Layer 3: Parking polygons
+    for pkg in osm_features.parking:
+        coords = _geometry_to_pixel_coords(
+            pkg.geometry, ref_lat, ref_lon, size_x, size_y, grid_size)
+        if len(coords) >= 3:
+            draw.polygon(coords, fill=_PARKING_COLOR)
+
+    # Layer 4: Roads with width
+    meters_per_pixel = size_x / (grid_size - 1)
+    for road in osm_features.roads:
+        style = _ROAD_STYLES.get(road.highway, _DEFAULT_ROAD_STYLE)
+        pixel_width = max(1, round(style["width"] / meters_per_pixel))
+        coords = _geometry_to_pixel_coords(
+            road.geometry, ref_lat, ref_lon, size_x, size_y, grid_size)
+        if len(coords) >= 2:
+            draw.line(coords, fill=style["color"], width=pixel_width)
+
+    # Apply water mask: reset underwater pixels to base color
+    if terrain is not None:
+        arr = np.array(img)
+        water_mask = terrain <= 0.0
+        arr[water_mask] = LAND_BASE
+        img = Image.fromarray(arr)
+
+    n_features = (len(osm_features.landuse) + len(osm_features.natural)
+                  + len(osm_features.parking) + len(osm_features.roads))
+    logger.info("Rasterized %d terrain features onto %dx%d texture",
+                n_features, grid_size, grid_size)
+
+    return img

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_texture.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_texture.py
@@ -89,14 +89,21 @@ _MAN_MADE_STYLES = {
 _DEFAULT_MAN_MADE_STYLE = {"color": (160, 155, 150), "width": 3.0}
 
 
-def _latlon_to_pixel(lats, lons, ref_lat, ref_lon, size_x, size_y, grid_size):
+def _latlon_to_pixel(lats, lons, ref_lat, ref_lon, tex_size, size_x, size_y,
+                     grid_size):
     """Convert lat/lon arrays to pixel coordinates.
+
+    The texture is a square image (grid_size x grid_size) that covers
+    tex_size x tex_size meters (where tex_size = max(size_x, size_y)).
+    The heightmap extent (size_x x size_y) is centered within this
+    square so that Gazebo's UV mapping aligns features correctly.
 
     Args:
         lats: numpy array of latitudes.
         lons: numpy array of longitudes.
         ref_lat: Reference latitude (terrain center).
         ref_lon: Reference longitude (terrain center).
+        tex_size: Texture tiling size in meters (square).
         size_x: Terrain width in meters.
         size_y: Terrain height in meters.
         grid_size: Image size in pixels.
@@ -109,14 +116,14 @@ def _latlon_to_pixel(lats, lons, ref_lat, ref_lon, size_x, size_y, grid_size):
         np.asarray(lons, dtype=np.float64),
         ref_lat, ref_lon,
     )
-    # ENU origin is at center; pixels go from 0 to grid_size-1
-    px = (east + size_x / 2) / size_x * (grid_size - 1)
-    py = (grid_size - 1) - (north + size_y / 2) / size_y * (grid_size - 1)
+    # ENU origin is at center; map to square texture of tex_size meters
+    px = (east + tex_size / 2) / tex_size * (grid_size - 1)
+    py = (grid_size - 1) - (north + tex_size / 2) / tex_size * (grid_size - 1)
     return list(zip(px.tolist(), py.tolist()))
 
 
 def _geometry_to_pixel_coords(geom, ref_lat, ref_lon,
-                              size_x, size_y, grid_size):
+                              tex_size, size_x, size_y, grid_size):
     """Extract coordinates from an OGR geometry and convert to pixels.
 
     For polygons, returns the exterior ring coordinates.
@@ -128,7 +135,7 @@ def _geometry_to_pixel_coords(geom, ref_lat, ref_lon,
         lats = [geom.GetY(i) for i in range(geom.GetPointCount())]
         lons = [geom.GetX(i) for i in range(geom.GetPointCount())]
         return _latlon_to_pixel(lats, lons, ref_lat, ref_lon,
-                                size_x, size_y, grid_size)
+                                tex_size, size_x, size_y, grid_size)
 
     if geom_type == 3:  # Polygon
         ring = geom.GetGeometryRef(0)  # exterior ring
@@ -137,7 +144,7 @@ def _geometry_to_pixel_coords(geom, ref_lat, ref_lon,
         lats = [ring.GetY(i) for i in range(ring.GetPointCount())]
         lons = [ring.GetX(i) for i in range(ring.GetPointCount())]
         return _latlon_to_pixel(lats, lons, ref_lat, ref_lon,
-                                size_x, size_y, grid_size)
+                                tex_size, size_x, size_y, grid_size)
 
     return []
 
@@ -176,6 +183,12 @@ def rasterize_osm_texture(
     size_x = terrain_info["size_x"]
     size_y = terrain_info["size_y"]
 
+    # Gazebo heightmap texture <size> uses a single value for both U and V
+    # tiling.  For non-square heightmaps we use the larger dimension so the
+    # texture covers the full extent without clipping.  Features are
+    # rasterized into the correct region of this square texture.
+    tex_size = max(size_x, size_y)
+
     # Start with base land color
     img = Image.new("RGB", (grid_size, grid_size), LAND_BASE)
     draw = ImageDraw.Draw(img)
@@ -186,7 +199,8 @@ def rasterize_osm_texture(
         if color is None:
             continue
         coords = _geometry_to_pixel_coords(
-            lu.geometry, ref_lat, ref_lon, size_x, size_y, grid_size)
+            lu.geometry, ref_lat, ref_lon,
+            tex_size, size_x, size_y, grid_size)
         if len(coords) >= 3:
             draw.polygon(coords, fill=color)
 
@@ -196,24 +210,27 @@ def rasterize_osm_texture(
         if color is None:
             continue
         coords = _geometry_to_pixel_coords(
-            nat.geometry, ref_lat, ref_lon, size_x, size_y, grid_size)
+            nat.geometry, ref_lat, ref_lon,
+            tex_size, size_x, size_y, grid_size)
         if len(coords) >= 3:
             draw.polygon(coords, fill=color)
 
     # Layer 3: Parking polygons
     for pkg in osm_features.parking:
         coords = _geometry_to_pixel_coords(
-            pkg.geometry, ref_lat, ref_lon, size_x, size_y, grid_size)
+            pkg.geometry, ref_lat, ref_lon,
+            tex_size, size_x, size_y, grid_size)
         if len(coords) >= 3:
             draw.polygon(coords, fill=_PARKING_COLOR)
 
     # Layer 4: Marine infrastructure (man_made polygons and linestrings)
-    meters_per_pixel = size_x / (grid_size - 1)
+    meters_per_pixel = tex_size / (grid_size - 1)
     for mm in osm_features.man_made:
         style = _MAN_MADE_STYLES.get(mm.man_made, _DEFAULT_MAN_MADE_STYLE)
         geom_type = mm.geometry.GetGeometryType() & 0xFF
         coords = _geometry_to_pixel_coords(
-            mm.geometry, ref_lat, ref_lon, size_x, size_y, grid_size)
+            mm.geometry, ref_lat, ref_lon,
+            tex_size, size_x, size_y, grid_size)
         if geom_type == 3 and len(coords) >= 3:  # Polygon
             draw.polygon(coords, fill=style["color"])
         elif len(coords) >= 2:  # LineString
@@ -225,7 +242,8 @@ def rasterize_osm_texture(
         style = _ROAD_STYLES.get(road.highway, _DEFAULT_ROAD_STYLE)
         pixel_width = max(1, round(style["width"] / meters_per_pixel))
         coords = _geometry_to_pixel_coords(
-            road.geometry, ref_lat, ref_lon, size_x, size_y, grid_size)
+            road.geometry, ref_lat, ref_lon,
+            tex_size, size_x, size_y, grid_size)
         if len(coords) >= 2:
             draw.line(coords, fill=style["color"], width=pixel_width)
 
@@ -242,4 +260,4 @@ def rasterize_osm_texture(
     logger.info("Rasterized %d terrain features onto %dx%d texture",
                 n_features, grid_size, grid_size)
 
-    return img
+    return img, tex_size

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_texture.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_texture.py
@@ -159,7 +159,7 @@ def rasterize_osm_texture(
     ref_lat: float,
     ref_lon: float,
     terrain: Optional[np.ndarray] = None,
-) -> Image.Image:
+) -> tuple:
     """Rasterize OSM features onto a texture image for heightmap land areas.
 
     Renders features back-to-front:
@@ -181,7 +181,7 @@ def rasterize_osm_texture(
         terrain: Optional terrain elevation array for water masking.
 
     Returns:
-        PIL Image (RGB) of the rasterized texture.
+        Tuple of (PIL Image (RGB) of the rasterized texture, tex_size in meters).
     """
     size_x = terrain_info["size_x"]
     size_y = terrain_info["size_y"]

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_texture.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_texture.py
@@ -215,11 +215,6 @@ def rasterize_osm_texture(
         arr[water_mask] = LAND_BASE
         img = Image.fromarray(arr)
 
-    # Flip vertically: our rasterizer puts north at row 0 (top), but
-    # Gazebo OGRE2 heightmap textures have UV (0,0) at the southwest
-    # corner, so pixel (0,0) must be the south edge.
-    img = img.transpose(Image.FLIP_TOP_BOTTOM)
-
     n_features = (len(osm_features.landuse) + len(osm_features.natural)
                   + len(osm_features.parking) + len(osm_features.roads))
     logger.info("Rasterized %d terrain features onto %dx%d texture",

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_texture.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_texture.py
@@ -79,6 +79,15 @@ _ROAD_STYLES = {
 }
 _DEFAULT_ROAD_STYLE = {"color": (170, 170, 165), "width": 4.0}
 
+# Marine infrastructure colors and widths by man_made type
+_MAN_MADE_STYLES = {
+    "pier": {"color": (180, 175, 165), "width": 3.0},       # light gray
+    "quay": {"color": (160, 155, 150), "width": 4.0},       # medium gray
+    "breakwater": {"color": (140, 140, 135), "width": 5.0},  # dark gray
+    "groyne": {"color": (140, 140, 135), "width": 3.0},      # dark gray
+}
+_DEFAULT_MAN_MADE_STYLE = {"color": (160, 155, 150), "width": 3.0}
+
 
 def _latlon_to_pixel(lats, lons, ref_lat, ref_lon, size_x, size_y, grid_size):
     """Convert lat/lon arrays to pixel coordinates.
@@ -198,8 +207,20 @@ def rasterize_osm_texture(
         if len(coords) >= 3:
             draw.polygon(coords, fill=_PARKING_COLOR)
 
-    # Layer 4: Roads with width
+    # Layer 4: Marine infrastructure (man_made polygons and linestrings)
     meters_per_pixel = size_x / (grid_size - 1)
+    for mm in osm_features.man_made:
+        style = _MAN_MADE_STYLES.get(mm.man_made, _DEFAULT_MAN_MADE_STYLE)
+        geom_type = mm.geometry.GetGeometryType() & 0xFF
+        coords = _geometry_to_pixel_coords(
+            mm.geometry, ref_lat, ref_lon, size_x, size_y, grid_size)
+        if geom_type == 3 and len(coords) >= 3:  # Polygon
+            draw.polygon(coords, fill=style["color"])
+        elif len(coords) >= 2:  # LineString
+            pixel_width = max(1, round(style["width"] / meters_per_pixel))
+            draw.line(coords, fill=style["color"], width=pixel_width)
+
+    # Layer 5: Roads with width
     for road in osm_features.roads:
         style = _ROAD_STYLES.get(road.highway, _DEFAULT_ROAD_STYLE)
         pixel_width = max(1, round(style["width"] / meters_per_pixel))
@@ -216,7 +237,8 @@ def rasterize_osm_texture(
         img = Image.fromarray(arr)
 
     n_features = (len(osm_features.landuse) + len(osm_features.natural)
-                  + len(osm_features.parking) + len(osm_features.roads))
+                  + len(osm_features.parking) + len(osm_features.roads)
+                  + len(osm_features.man_made))
     logger.info("Rasterized %d terrain features onto %dx%d texture",
                 n_features, grid_size, grid_size)
 

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_texture.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_texture.py
@@ -117,11 +117,11 @@ def _latlon_to_pixel(lats, lons, ref_lat, ref_lon, tex_size, size_x, size_y,
         ref_lat, ref_lon,
     )
     # Map ENU to UV coordinates, then to pixels.
-    # Gazebo heightmap UV: U goes [0, size_x/tex_size] west-to-east,
-    # V goes [0, size_y/tex_size] south-to-north.
-    # Image row 0 = top (V=1), row grid_size-1 = bottom (V=0 = south).
+    # Gazebo OGRE2 heightmap: image row 0 = north edge, V=0.
+    # V increases southward: V = size_y/tex_size at the south edge.
+    # U=0 at the west edge, increases eastward.
     px = (east + size_x / 2) / tex_size * (grid_size - 1)
-    py = (grid_size - 1) - (north + size_y / 2) / tex_size * (grid_size - 1)
+    py = (size_y / 2 - north) / tex_size * (grid_size - 1)
     return list(zip(px.tolist(), py.tolist()))
 
 

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_texture.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_texture.py
@@ -116,9 +116,12 @@ def _latlon_to_pixel(lats, lons, ref_lat, ref_lon, tex_size, size_x, size_y,
         np.asarray(lons, dtype=np.float64),
         ref_lat, ref_lon,
     )
-    # ENU origin is at center; map to square texture of tex_size meters
-    px = (east + tex_size / 2) / tex_size * (grid_size - 1)
-    py = (grid_size - 1) - (north + tex_size / 2) / tex_size * (grid_size - 1)
+    # Map ENU to UV coordinates, then to pixels.
+    # Gazebo heightmap UV: U goes [0, size_x/tex_size] west-to-east,
+    # V goes [0, size_y/tex_size] south-to-north.
+    # Image row 0 = top (V=1), row grid_size-1 = bottom (V=0 = south).
+    px = (east + size_x / 2) / tex_size * (grid_size - 1)
+    py = (grid_size - 1) - (north + size_y / 2) / tex_size * (grid_size - 1)
     return list(zip(px.tolist(), py.tolist()))
 
 

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_texture.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/osm_texture.py
@@ -215,6 +215,11 @@ def rasterize_osm_texture(
         arr[water_mask] = LAND_BASE
         img = Image.fromarray(arr)
 
+    # Flip vertically: our rasterizer puts north at row 0 (top), but
+    # Gazebo OGRE2 heightmap textures have UV (0,0) at the southwest
+    # corner, so pixel (0,0) must be the south edge.
+    img = img.transpose(Image.FLIP_TOP_BOTTOM)
+
     n_features = (len(osm_features.landuse) + len(osm_features.natural)
                   + len(osm_features.parking) + len(osm_features.roads))
     logger.info("Rasterized %d terrain features onto %dx%d texture",

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/s57_reader.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/s57_reader.py
@@ -86,6 +86,7 @@ class Building:
     osm_height: Optional[float] = None  # from OSM height or levels*3
     osm_material: str = ''  # from OSM building:material
     osm_colour: str = ''  # from OSM building:colour
+    osm_only: bool = False  # True if building came from OSM with no S57 match
 
 
 @dataclass

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/s57_reader.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/s57_reader.py
@@ -130,6 +130,8 @@ class ShoreCon:
     geometry: ogr.Geometry  # Line, Polygon, or Point in WGS84
     catslc: int = 0  # CATSLC category (1=breakwater, 4=pier, etc.)
     watlev: int = 0  # WATLEV water level (2=always dry, 4=covers/uncovers)
+    osm_geometry: Optional[ogr.Geometry] = None  # polygon from OSM match
+    osm_only: bool = False  # True if from OSM with no S57 match
 
 
 @dataclass

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/world_builder.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/world_builder.py
@@ -128,7 +128,8 @@ def generate_world_sdf(
     output_dir: str,
     heightmap_info,
     camera_config: dict = None,
-    feature_models: str = "",
+    s57_feature_models: str = "",
+    osm_feature_models: str = "",
     water_size_x: float = 0.0,
     water_size_y: float = 0.0,
 ) -> str:
@@ -141,7 +142,7 @@ def generate_world_sdf(
     - Terrain heightmap model(s)
     - Semi-transparent water surface plane
     - Scene with sky and lighting
-    - Optional S57 chart feature models (buildings, buoys, etc.)
+    - Optional S57/OSM chart feature models (buildings, buoys, etc.)
 
     Args:
         world_name: Name for the world (used in filename and SDF).
@@ -151,7 +152,8 @@ def generate_world_sdf(
         heightmap_info: dict from terrain_to_heightmap() for single tile,
             or list of dicts for multi-tile.
         camera_config: optional dict with camera overrides (see _compute_camera).
-        feature_models: SDF model XML strings for S57 features (default empty).
+        s57_feature_models: SDF XML for S57-sourced features (default empty).
+        osm_feature_models: SDF XML for OSM-sourced features (default empty).
         water_size_x: Override water plane width (meters). If 0, uses
             heightmap_info size.
         water_size_y: Override water plane height (meters). If 0, uses
@@ -189,7 +191,8 @@ def generate_world_sdf(
         terrain_includes=terrain_includes,
         camera_pose=camera_pose,
         camera_far=camera_far,
-        feature_models=feature_models,
+        s57_feature_models=s57_feature_models,
+        osm_feature_models=osm_feature_models,
     )
 
     sdf_path = os.path.join(output_dir, f"{world_name}.sdf")

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/world_template.sdf.xml
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/world_template.sdf.xml
@@ -237,7 +237,9 @@
       </link>
     </model>
 
-{feature_models}
+{s57_feature_models}
+
+{osm_feature_models}
 
   </world>
 </sdf>

--- a/marine_charts_to_gazebo_world/test/test_feature_models.py
+++ b/marine_charts_to_gazebo_world/test/test_feature_models.py
@@ -38,6 +38,13 @@ CENTER_LAT = 43.075
 CENTER_LON = -70.71
 
 
+def _all_features_sdf(features, *args, **kwargs):
+    """Call generate_feature_models and join s57+osm output."""
+    result = generate_feature_models(features, *args, **kwargs)
+    parts = [v for v in (result['s57'], result['osm']) if v]
+    return '\n\n'.join(parts)
+
+
 def _make_polygon(coords):
     """Create an OGR polygon from a list of (lon, lat) tuples."""
     ring = ogr.Geometry(ogr.wkbLinearRing)
@@ -78,10 +85,10 @@ class TestLatLonToEnu:
 class TestGenerateFeatureModelsEmpty:
 
     def test_empty_features(self):
-        """Empty features should return empty string."""
+        """Empty features should return dict with empty strings."""
         features = S57Features()
         result = generate_feature_models(features, CENTER_LAT, CENTER_LON)
-        assert result == ''
+        assert result == {'s57': '', 'osm': ''}
 
 
 class TestBuildingModel:
@@ -95,14 +102,15 @@ class TestBuildingModel:
             (-70.711, 43.077),
         ])
         features = S57Features(buildings=[Building(geometry=poly, objl=12)])
-        result = generate_feature_models(features, CENTER_LAT, CENTER_LON)
+        result = _all_features_sdf(features, CENTER_LAT, CENTER_LON)
         assert '<model name="building_0000">' in result
         assert '<polyline>' in result
         assert '<height>5.0</height>' in result
-        # Should be valid XML when wrapped
+        # Should be valid XML when wrapped — building is nested inside
+        # s57_features/buildings container
         root = ET.fromstring(f'<root>{result}</root>')
-        models = root.findall('model')
-        assert len(models) == 1
+        buildings = root.findall('.//model[@name="building_0000"]')
+        assert len(buildings) == 1
 
     def test_landmark_height(self):
         """LNDMRK (OBJL 73) should use 12.0m height."""
@@ -113,7 +121,7 @@ class TestBuildingModel:
             (-70.711, 43.077),
         ])
         features = S57Features(buildings=[Building(geometry=poly, objl=73)])
-        result = generate_feature_models(features, CENTER_LAT, CENTER_LON)
+        result = _all_features_sdf(features, CENTER_LAT, CENTER_LON)
         assert '<height>12.0</height>' in result
 
     def test_silo_height(self):
@@ -125,7 +133,7 @@ class TestBuildingModel:
             (-70.711, 43.077),
         ])
         features = S57Features(buildings=[Building(geometry=poly, objl=119)])
-        result = generate_feature_models(features, CENTER_LAT, CENTER_LON)
+        result = _all_features_sdf(features, CENTER_LAT, CENTER_LON)
         assert '<height>8.0</height>' in result
 
 
@@ -143,7 +151,7 @@ class TestBuildingObjnam:
             buildings=[Building(geometry=poly, objl=12,
                                 objnam='Coast Guard Station')]
         )
-        result = generate_feature_models(features, CENTER_LAT, CENTER_LON)
+        result = _all_features_sdf(features, CENTER_LAT, CENTER_LON)
         assert '<model name="building_0000_coast_guard_station">' in result
 
     def test_empty_objnam_uses_default(self):
@@ -157,7 +165,7 @@ class TestBuildingObjnam:
         features = S57Features(
             buildings=[Building(geometry=poly, objl=12, objnam='')]
         )
-        result = generate_feature_models(features, CENTER_LAT, CENTER_LON)
+        result = _all_features_sdf(features, CENTER_LAT, CENTER_LON)
         assert '<model name="building_0000">' in result
 
     def test_special_chars_sanitized(self):
@@ -172,7 +180,7 @@ class TestBuildingObjnam:
             buildings=[Building(geometry=poly, objl=12,
                                 objnam='Bldg #42 (Main)')]
         )
-        result = generate_feature_models(features, CENTER_LAT, CENTER_LON)
+        result = _all_features_sdf(features, CENTER_LAT, CENTER_LON)
         assert '<model name="building_0000_bldg_42_main">' in result
 
 
@@ -203,7 +211,7 @@ class TestPontoonModel:
             (-70.711, 43.077),
         ])
         features = S57Features(pontoons=[Pontoon(geometry=poly)])
-        result = generate_feature_models(features, CENTER_LAT, CENTER_LON)
+        result = _all_features_sdf(features, CENTER_LAT, CENTER_LON)
         assert '<model name="pontoon_0000">' in result
         assert '<height>1.0</height>' in result
 
@@ -221,7 +229,7 @@ class TestBridgeModel:
         features = S57Features(
             bridges=[Bridge(geometry=poly, clearance=15.0)]
         )
-        result = generate_feature_models(features, CENTER_LAT, CENTER_LON)
+        result = _all_features_sdf(features, CENTER_LAT, CENTER_LON)
         assert '<model name="bridge_0000">' in result
         # Deck thickness is 1.0m, placed at z=15.0
         assert '<height>1.0</height>' in result
@@ -236,7 +244,7 @@ class TestBridgeModel:
             (-70.711, 43.077),
         ])
         features = S57Features(bridges=[Bridge(geometry=poly, clearance=0.0)])
-        result = generate_feature_models(features, CENTER_LAT, CENTER_LON)
+        result = _all_features_sdf(features, CENTER_LAT, CENTER_LON)
         # Deck at z=10.0 with 1.0m thickness
         assert '<height>1.0</height>' in result
         assert '10.00 0 0 0' in result
@@ -249,19 +257,19 @@ class TestBuoyModel:
         features = S57Features(
             buoys=[Buoy(lat=43.076, lon=-70.711, colour=3)]
         )
-        result = generate_feature_models(features, CENTER_LAT, CENTER_LON)
+        result = _all_features_sdf(features, CENTER_LAT, CENTER_LON)
         assert '<model name="buoy_0000">' in result
         assert '<cylinder>' in result
         assert '<cone>' in result
         root = ET.fromstring(f'<root>{result}</root>')
-        assert len(root.findall('model')) == 1
+        assert len(root.findall('.//model[@name="buoy_0000"]')) == 1
 
     def test_buoy_red_colour(self):
         """Buoy with COLOUR=3 (red) should have red material."""
         features = S57Features(
             buoys=[Buoy(lat=43.076, lon=-70.711, colour=3)]
         )
-        result = generate_feature_models(features, CENTER_LAT, CENTER_LON)
+        result = _all_features_sdf(features, CENTER_LAT, CENTER_LON)
         # Red: 1.0 0.0 0.0
         assert '1.0 0.0 0.0 1.0' in result
 
@@ -270,7 +278,7 @@ class TestBuoyModel:
         features = S57Features(
             buoys=[Buoy(lat=43.076, lon=-70.711, colour=4)]
         )
-        result = generate_feature_models(features, CENTER_LAT, CENTER_LON)
+        result = _all_features_sdf(features, CENTER_LAT, CENTER_LON)
         assert '0.0 0.8 0.0 1.0' in result
 
     def test_buoy_unknown_colour_defaults_yellow(self):
@@ -278,7 +286,7 @@ class TestBuoyModel:
         features = S57Features(
             buoys=[Buoy(lat=43.076, lon=-70.711, colour=99)]
         )
-        result = generate_feature_models(features, CENTER_LAT, CENTER_LON)
+        result = _all_features_sdf(features, CENTER_LAT, CENTER_LON)
         assert '1.0 1.0 0.0 1.0' in result
 
 
@@ -289,11 +297,11 @@ class TestBeaconModel:
         features = S57Features(
             beacons=[Beacon(lat=43.076, lon=-70.711)]
         )
-        result = generate_feature_models(features, CENTER_LAT, CENTER_LON)
+        result = _all_features_sdf(features, CENTER_LAT, CENTER_LON)
         assert '<model name="beacon_0000">' in result
         assert '<cylinder>' in result
         root = ET.fromstring(f'<root>{result}</root>')
-        assert len(root.findall('model')) == 1
+        assert len(root.findall('.//model[@name="beacon_0000"]')) == 1
 
 
 class TestLightModel:
@@ -303,12 +311,12 @@ class TestLightModel:
         features = S57Features(
             lights=[Light(lat=43.076, lon=-70.711)]
         )
-        result = generate_feature_models(features, CENTER_LAT, CENTER_LON)
+        result = _all_features_sdf(features, CENTER_LAT, CENTER_LON)
         assert '<model name="light_0000">' in result
         assert '<cylinder>' in result
         assert '<sphere>' in result
         root = ET.fromstring(f'<root>{result}</root>')
-        assert len(root.findall('model')) == 1
+        assert len(root.findall('.//model[@name="light_0000"]')) == 1
 
 
 class TestMultipleFeatures:
@@ -326,9 +334,12 @@ class TestMultipleFeatures:
             buoys=[Buoy(lat=43.076, lon=-70.711, colour=3)],
             lights=[Light(lat=43.076, lon=-70.712)],
         )
-        result = generate_feature_models(features, CENTER_LAT, CENTER_LON)
+        result = _all_features_sdf(features, CENTER_LAT, CENTER_LON)
         assert 'building_0000' in result
         assert 'buoy_0000' in result
         assert 'light_0000' in result
         root = ET.fromstring(f'<root>{result}</root>')
-        assert len(root.findall('model')) == 3
+        # Top-level container is s57_features; individual features are nested
+        assert len(root.findall('.//model[@name="building_0000"]')) == 1
+        assert len(root.findall('.//model[@name="buoy_0000"]')) == 1
+        assert len(root.findall('.//model[@name="light_0000"]')) == 1

--- a/marine_charts_to_gazebo_world/test/test_world_builder.py
+++ b/marine_charts_to_gazebo_world/test/test_world_builder.py
@@ -165,7 +165,7 @@ class TestGenerateWorldSdf:
                 center_lon=-70.71,
                 output_dir=tmpdir,
                 heightmap_info=heightmap_info,
-                feature_models=feature_xml,
+                s57_feature_models=feature_xml,
             )
             with open(sdf_path) as f:
                 content = f.read()

--- a/portsmouth_nh_gazebo/CMakeLists.txt
+++ b/portsmouth_nh_gazebo/CMakeLists.txt
@@ -75,6 +75,9 @@ add_gazebo_world(portsmouth_nh_isles_of_shoals
 add_gazebo_world(portsmouth_nh_portsmouth_to_isles
   "${CMAKE_CURRENT_SOURCE_DIR}/config/portsmouth_to_isles.yaml")
 
+add_gazebo_world(portsmouth_nh_unh_pier
+  "${CMAKE_CURRENT_SOURCE_DIR}/config/unh_pier.yaml")
+
 # ---------- Install ----------
 
 # Launch files

--- a/portsmouth_nh_gazebo/config/isles_of_shoals.yaml
+++ b/portsmouth_nh_gazebo/config/isles_of_shoals.yaml
@@ -8,11 +8,4 @@ world_name: portsmouth_nh_isles_of_shoals
 
 grid_power: 10   # 1025x1025
 
-skip_categories:
-  - buoys
-  - beacons
-  - piles
-  - mooring_facilities
-  - cranes
-  - pylons
-  - rip_rap
+osm: true

--- a/portsmouth_nh_gazebo/config/portsmouth.yaml
+++ b/portsmouth_nh_gazebo/config/portsmouth.yaml
@@ -10,13 +10,3 @@ world_name: portsmouth_nh_harbor
 grid_power: 10   # 1025x1025 (~3.2 m/cell)
 
 osm: true
-no_osm_buildings: true
-
-skip_categories:
-  - buoys
-  - beacons
-  - piles
-  - mooring_facilities
-  - cranes
-  - pylons
-  - rip_rap

--- a/portsmouth_nh_gazebo/config/portsmouth.yaml
+++ b/portsmouth_nh_gazebo/config/portsmouth.yaml
@@ -9,6 +9,9 @@ world_name: portsmouth_nh_harbor
 
 grid_power: 10   # 1025x1025 (~3.2 m/cell)
 
+osm: true
+no_osm_buildings: true
+
 skip_categories:
   - buoys
   - beacons

--- a/portsmouth_nh_gazebo/config/portsmouth_to_isles.yaml
+++ b/portsmouth_nh_gazebo/config/portsmouth_to_isles.yaml
@@ -29,11 +29,4 @@ tiles:
     east: -70.565
     grid_power: 10   # 1025x1025
 
-skip_categories:
-  - buoys
-  - beacons
-  - piles
-  - mooring_facilities
-  - cranes
-  - pylons
-  - rip_rap
+osm: true

--- a/portsmouth_nh_gazebo/config/unh_pier.yaml
+++ b/portsmouth_nh_gazebo/config/unh_pier.yaml
@@ -1,0 +1,13 @@
+bounds:
+  south: 43.069694
+  west: -70.7148459
+  north: 43.0727356
+  east: -70.7067844
+
+world_name: portsmouth_nh_unh_pier
+
+grid_power: 10   # 1025x1025 (~0.35 m/cell for this small area)
+
+osm: true
+# No skip_categories — show all features
+# No no_osm_buildings — include OSM-only buildings too

--- a/portsmouth_nh_gazebo/config/unh_pier.yaml
+++ b/portsmouth_nh_gazebo/config/unh_pier.yaml
@@ -9,5 +9,3 @@ world_name: portsmouth_nh_unh_pier
 grid_power: 10   # 1025x1025 (~0.35 m/cell for this small area)
 
 osm: true
-# No skip_categories — show all features
-# No no_osm_buildings — include OSM-only buildings too

--- a/portsmouth_nh_gazebo/launch/unh_pier_launch.py
+++ b/portsmouth_nh_gazebo/launch/unh_pier_launch.py
@@ -1,0 +1,59 @@
+# Copyright 2025 Roland Arsenault
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Launch Gazebo with the UNH Pier world."""
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import (
+    DeclareLaunchArgument,
+    ExecuteProcess,
+    OpaqueFunction,
+    Shutdown,
+)
+from launch.substitutions import LaunchConfiguration
+
+WORLD_NAME = 'portsmouth_nh_unh_pier'
+
+
+def _launch_gazebo(context, *args, **kwargs):
+    verbose = LaunchConfiguration('verbose').perform(context) == 'true'
+    pkg_share = get_package_share_directory('portsmouth_nh_gazebo')
+    sdf_path = os.path.join(
+        pkg_share, 'worlds', WORLD_NAME, f'{WORLD_NAME}.sdf'
+    )
+    if not os.path.exists(sdf_path):
+        raise RuntimeError(
+            f'World SDF not found at {sdf_path}. '
+            'Rebuild: colcon build --packages-select portsmouth_nh_gazebo'
+        )
+    return [
+        ExecuteProcess(
+            cmd=['gz', 'sim', '-v4' if verbose else '-v1', sdf_path],
+            output='screen',
+            on_exit=Shutdown(),
+        ),
+    ]
+
+
+def generate_launch_description():
+    return LaunchDescription([
+        DeclareLaunchArgument(
+            'verbose', default_value='false',
+            description='Enable verbose Gazebo output',
+        ),
+        OpaqueFunction(function=_launch_gazebo),
+    ])

--- a/portsmouth_nh_gazebo/scripts/build_world.py
+++ b/portsmouth_nh_gazebo/scripts/build_world.py
@@ -137,6 +137,8 @@ def main():
     # OSM enrichment (optional)
     if config.get('osm'):
         gen_args.append('--osm')
+    if config.get('no_osm_buildings'):
+        gen_args.append('--no-osm-buildings')
 
     # ETOPO bathymetry (optional)
     if config.get('fetch_etopo'):

--- a/portsmouth_nh_gazebo/scripts/build_world.py
+++ b/portsmouth_nh_gazebo/scripts/build_world.py
@@ -167,6 +167,11 @@ def main():
     if max_segs is not None:
         gen_args.extend(['--max-wall-segments', str(max_segs)])
 
+    # Tree count cap (optional)
+    max_trees = config.get('max_trees')
+    if max_trees is not None:
+        gen_args.extend(['--max-trees', str(max_trees)])
+
     # ENC root: config override takes precedence, then env var
     enc_root = config.get('enc_root') or os.environ.get('ROS_S57_ENC_ROOT')
     if enc_root:

--- a/portsmouth_nh_gazebo/scripts/build_world.py
+++ b/portsmouth_nh_gazebo/scripts/build_world.py
@@ -139,6 +139,8 @@ def main():
         gen_args.append('--osm')
     if config.get('no_osm_buildings'):
         gen_args.append('--no-osm-buildings')
+    if config.get('osm_matching'):
+        gen_args.append('--osm-matching')
 
     # ETOPO bathymetry (optional)
     if config.get('fetch_etopo'):


### PR DESCRIPTION
## Summary

- **OSM marine infrastructure**: Parse piers, quays, breakwaters, groynes with floating/fixed distinction. Fix tag priority so piers with landuse tags aren't misclassified. Distinguish open linestrings from closed polygons.
- **Polyline extrusion for walls**: Replace individual box segments with single polyline extrusions using mitered joints. Handles closed linestrings by splitting into two open segments.
- **Water-level-aware rendering**: SLCONS features rendered based on S57 `watlev` attribute (floating, tidal, submerged) and OSM `floating` tag.
- **Bridge/gangway rendering**: Detect `bridge=yes` roads and render as sloped box segments, auto-detecting which end connects to floating vs fixed piers.
- **Config cleanup**: `--no-osm-matching` replaced with `--osm-matching` opt-in (independent rendering is now the default). All Portsmouth world configs enable OSM with all feature categories.

## Test plan

- [x] UNH pier world — launches cleanly with GUI
- [x] Portsmouth harbor world — launches cleanly with GUI
- [x] Isles of Shoals world — launches cleanly with GUI
- [x] Portsmouth to Isles world — launches with 1 cosmetic triangulation warning (tracked in #43)
- [ ] Visual inspection of floating piers, gangways, and wall joints
- [ ] Verify `--osm-matching` opt-in still works for merged rendering

Closes #34

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
