### PR TITLE
Add Gazebo simulator launch for Portsmouth Harbor

### DIFF
--- a/marine_simulation/launch/gazebo_simulator_launch.py
+++ b/marine_simulation/launch/gazebo_simulator_launch.py
@@ -1,0 +1,161 @@
+"""Launch full Gazebo simulation: Portsmouth Harbor + BEN + autonomy stack.
+
+Parallel to simulator_launch.py but uses Gazebo instead of asv_sim for
+physics and gazebo_helm instead of asv_helm for thruster control.
+"""
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.actions import GroupAction
+from launch.actions import IncludeLaunchDescription
+from launch.conditions import IfCondition
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+from launch.substitutions import PathJoinSubstitution
+from launch.substitutions import PythonExpression
+from launch.substitutions import TextSubstitution
+from launch_ros.actions import LifecycleNode
+from launch_ros.actions import LifecycleTransition
+from launch_ros.actions import PushROSNamespace
+from launch_ros.actions import SetParameter
+from launch_ros.actions import SetRemap
+from launch_ros.substitutions import FindPackageShare
+
+from lifecycle_msgs.msg import Transition
+
+
+WORLD_NAME = 'portsmouth_nh_harbor'
+
+
+def generate_launch_description():
+    namespace = LaunchConfiguration('namespace')
+    background_chart = LaunchConfiguration('background_chart')
+    enable_bridge = LaunchConfiguration('enable_bridge')
+
+    namespace_arg = DeclareLaunchArgument(
+        'namespace', default_value=TextSubstitution(text='ben'))
+    background_chart_arg = DeclareLaunchArgument(
+        'background_chart', default_value=PathJoinSubstitution(
+            [FindPackageShare('camp'), 'workspace', '13283', '13283_2.KAP']
+        ))
+    enable_bridge_arg = DeclareLaunchArgument(
+        'enable_bridge', default_value=TextSubstitution(text='false'))
+
+    # Global use_sim_time for all nodes
+    set_use_sim_time = SetParameter(name='use_sim_time', value=True)
+
+    # 1. Start Gazebo with Portsmouth Harbor world
+    gz_harbor = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution([
+                FindPackageShare('portsmouth_nh_gazebo'),
+                'launch',
+                'harbor_launch.py'
+            ])
+        ),
+    )
+
+    # 2. Spawn BEN into the Portsmouth Harbor world
+    spawn_ben = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution([
+                FindPackageShare('ben_gazebo'),
+                'launch',
+                'spawn_ben_launch.py'
+            ])
+        ),
+        launch_arguments={
+            'namespace': namespace,
+            'world_name': WORLD_NAME,
+        }.items(),
+    )
+
+    # 3. Autonomy stack (skip robot_state_publisher — Gazebo provides one)
+    ben_core = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution([
+                FindPackageShare('ben_project11'),
+                'launch',
+                'ben_core_launch.py'
+            ])
+        ),
+        launch_arguments={
+            'namespace': namespace,
+            'enable_bridge': enable_bridge,
+            'is_simulator': 'true',
+            'launch_robot_state_publisher': 'false',
+        }.items(),
+    )
+
+    # 4. Gazebo helm (replaces asv_helm for Gazebo simulation)
+    #    Remappings match the sim_robot_launch.py pattern
+    gazebo_helm_group = GroupAction(
+        actions=[
+            PushROSNamespace(namespace),
+            SetRemap(src='helm', dst='marine/control/helm'),
+            SetRemap(src='cmd_vel', dst='marine/control/cmd_vel'),
+            SetRemap(src='odom', dst='odom'),
+            LifecycleNode(
+                package='ben_gazebo',
+                executable='gazebo_helm',
+                name='gazebo_helm',
+                namespace='',
+                respawn=True,
+                respawn_delay=2,
+                emulate_tty=True,
+            ),
+            LifecycleTransition(
+                lifecycle_node_names=(
+                    PythonExpression(
+                        expression=[
+                            '"',
+                            namespace,
+                            '" + "/gazebo_helm"'
+                        ],
+                    ),
+                ),
+                transition_ids=(
+                    Transition.TRANSITION_CONFIGURE,
+                    Transition.TRANSITION_ACTIVATE,
+                ),
+            ),
+        ],
+    )
+
+    # 5. Operator UI + RViz
+    sim_operator = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution([
+                FindPackageShare('marine_simulation'),
+                'launch',
+                'sim_operator_launch.py'
+            ])
+        ),
+        launch_arguments={
+            'robot_namespace': namespace,
+            'operator_namespace': 'operator',
+            'enable_bridge': enable_bridge,
+            'background_chart': background_chart,
+            'rviz': 'true',
+            'rviz_configuration': PathJoinSubstitution([
+                FindPackageShare('ben_project11'),
+                'config',
+                'ben.rviz'
+            ]),
+        }.items(),
+    )
+
+    return LaunchDescription([
+        namespace_arg,
+        background_chart_arg,
+        enable_bridge_arg,
+        set_use_sim_time,
+        gz_harbor,
+        spawn_ben,
+        ben_core,
+        gazebo_helm_group,
+        sim_operator,
+    ])

--- a/marine_simulation/launch/gazebo_simulator_launch.py
+++ b/marine_simulation/launch/gazebo_simulator_launch.py
@@ -1,17 +1,42 @@
+# Copyright 2026 Roland Arsenault, UNH CCOM
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
 """Launch full Gazebo simulation: Portsmouth Harbor + BEN + autonomy stack.
 
 Parallel to simulator_launch.py but uses Gazebo instead of asv_sim for
 physics and gazebo_helm instead of asv_helm for thruster control.
 """
 
-import os
-
-from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.actions import GroupAction
 from launch.actions import IncludeLaunchDescription
-from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch.substitutions import PathJoinSubstitution
@@ -97,7 +122,6 @@ def generate_launch_description():
             PushROSNamespace(namespace),
             SetRemap(src='helm', dst='marine/control/helm'),
             SetRemap(src='cmd_vel', dst='marine/control/cmd_vel'),
-            SetRemap(src='odom', dst='odom'),
             LifecycleNode(
                 package='ben_gazebo',
                 executable='gazebo_helm',
@@ -139,6 +163,7 @@ def generate_launch_description():
             'operator_namespace': 'operator',
             'enable_bridge': enable_bridge,
             'background_chart': background_chart,
+            'use_sim_time': 'true',
             'rviz': 'true',
             'rviz_configuration': PathJoinSubstitution([
                 FindPackageShare('ben_project11'),

--- a/marine_simulation/package.xml
+++ b/marine_simulation/package.xml
@@ -19,6 +19,8 @@
   <exec_depend>marine_autonomy</exec_depend>
   <exec_depend>mbes_sim</exec_depend>
   <exec_depend>rviz2</exec_depend>
+  <exec_depend>ben_gazebo</exec_depend>
+  <exec_depend>portsmouth_nh_gazebo</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
 

--- a/marine_simulation/package.xml
+++ b/marine_simulation/package.xml
@@ -21,6 +21,9 @@
   <exec_depend>rviz2</exec_depend>
   <exec_depend>ben_gazebo</exec_depend>
   <exec_depend>portsmouth_nh_gazebo</exec_depend>
+  <exec_depend>ben_project11</exec_depend>
+  <exec_depend>camp</exec_depend>
+  <exec_depend>lifecycle_msgs</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
 


### PR DESCRIPTION
## Summary

- Add `gazebo_simulator_launch.py` — top-level launch for Gazebo-based BEN simulation in Portsmouth Harbor
- Replaces `asv_sim` physics with Gazebo and `asv_helm` with `gazebo_helm`
- Launches: Portsmouth Harbor world → BEN spawn → autonomy stack → gazebo_helm → operator UI
- Sets `use_sim_time: true` globally
- Add `ben_gazebo` and `portsmouth_nh_gazebo` exec dependencies to `package.xml`

### Cross-repo dependencies

- [rolker/ben_gazebo#9](https://github.com/rolker/ben_gazebo/pull/9) — Split launch + gazebo_helm node
- [rolker/ben_project11#11](https://github.com/rolker/ben_project11/pull/11) — launch_robot_state_publisher argument

Closes #25

## Test plan

- [ ] Merge ben_gazebo#9 and ben_project11#11 first
- [ ] `ros2 launch marine_simulation gazebo_simulator_launch.py`
  - [ ] Gazebo opens with Portsmouth Harbor visible
  - [ ] BEN spawned (model visible in Gz)
  - [ ] `ros2 topic list` shows `/ben/sensors/nav/*`, `/ben/thrusters/*`
  - [ ] TF tree: `ben/map` → `ben/odom` → `ben/base_link`
  - [ ] Joystick/operator commands move BEN
- [ ] Existing `ros2 launch marine_simulation simulator_launch.py` unaffected

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
