### PR TITLE
Split Gazebo launch and add physics engine support

### DIFF
--- a/marine_simulation/launch/gazebo_ben_launch.py
+++ b/marine_simulation/launch/gazebo_ben_launch.py
@@ -1,0 +1,91 @@
+# Copyright 2026 Roland Arsenault, UNH CCOM
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Launch Gazebo Portsmouth Harbor world and spawn BEN.
+
+Starts the Gazebo simulator with the Portsmouth NH Harbor world and
+spawns the BEN model into it. Can be used standalone for visualization
+or sensor testing, or included from a full simulation launch file.
+"""
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+from launch.substitutions import PathJoinSubstitution
+from launch.substitutions import TextSubstitution
+from launch_ros.actions import SetParameter
+from launch_ros.substitutions import FindPackageShare
+
+
+WORLD_NAME = 'portsmouth_nh_harbor'
+
+
+def generate_launch_description():
+    namespace = LaunchConfiguration('namespace')
+
+    namespace_arg = DeclareLaunchArgument(
+        'namespace', default_value=TextSubstitution(text='ben'))
+
+    # Global use_sim_time for all nodes
+    set_use_sim_time = SetParameter(name='use_sim_time', value=True)
+
+    # 1. Start Gazebo with Portsmouth Harbor world
+    gz_harbor = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution([
+                FindPackageShare('portsmouth_nh_gazebo'),
+                'launch',
+                'harbor_launch.py'
+            ])
+        ),
+    )
+
+    # 2. Spawn BEN into the Portsmouth Harbor world
+    spawn_ben = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution([
+                FindPackageShare('ben_gazebo'),
+                'launch',
+                'spawn_ben_launch.py'
+            ])
+        ),
+        launch_arguments={
+            'namespace': namespace,
+            'world_name': WORLD_NAME,
+        }.items(),
+    )
+
+    return LaunchDescription([
+        namespace_arg,
+        set_use_sim_time,
+        gz_harbor,
+        spawn_ben,
+    ])

--- a/marine_simulation/launch/gazebo_simulator_launch.py
+++ b/marine_simulation/launch/gazebo_simulator_launch.py
@@ -31,6 +31,9 @@
 
 Parallel to simulator_launch.py but uses Gazebo instead of asv_sim for
 physics and gazebo_helm instead of asv_helm for thruster control.
+
+Includes gazebo_ben_launch.py for the Gazebo world and BEN model, then
+adds the autonomy stack, gazebo helm, and operator UI on top.
 """
 
 from launch import LaunchDescription
@@ -45,14 +48,10 @@ from launch.substitutions import TextSubstitution
 from launch_ros.actions import LifecycleNode
 from launch_ros.actions import LifecycleTransition
 from launch_ros.actions import PushROSNamespace
-from launch_ros.actions import SetParameter
 from launch_ros.actions import SetRemap
 from launch_ros.substitutions import FindPackageShare
 
 from lifecycle_msgs.msg import Transition
-
-
-WORLD_NAME = 'portsmouth_nh_harbor'
 
 
 def generate_launch_description():
@@ -69,32 +68,17 @@ def generate_launch_description():
     enable_bridge_arg = DeclareLaunchArgument(
         'enable_bridge', default_value=TextSubstitution(text='false'))
 
-    # Global use_sim_time for all nodes
-    set_use_sim_time = SetParameter(name='use_sim_time', value=True)
-
-    # 1. Start Gazebo with Portsmouth Harbor world
-    gz_harbor = IncludeLaunchDescription(
+    # 1–2. Gazebo world + BEN model
+    gazebo_ben = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             PathJoinSubstitution([
-                FindPackageShare('portsmouth_nh_gazebo'),
+                FindPackageShare('marine_simulation'),
                 'launch',
-                'harbor_launch.py'
-            ])
-        ),
-    )
-
-    # 2. Spawn BEN into the Portsmouth Harbor world
-    spawn_ben = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            PathJoinSubstitution([
-                FindPackageShare('ben_gazebo'),
-                'launch',
-                'spawn_ben_launch.py'
+                'gazebo_ben_launch.py'
             ])
         ),
         launch_arguments={
             'namespace': namespace,
-            'world_name': WORLD_NAME,
         }.items(),
     )
 
@@ -177,9 +161,7 @@ def generate_launch_description():
         namespace_arg,
         background_chart_arg,
         enable_bridge_arg,
-        set_use_sim_time,
-        gz_harbor,
-        spawn_ben,
+        gazebo_ben,
         ben_core,
         gazebo_helm_group,
         sim_operator,

--- a/portsmouth_nh_gazebo/launch/harbor_launch.py
+++ b/portsmouth_nh_gazebo/launch/harbor_launch.py
@@ -18,12 +18,8 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import (
-    DeclareLaunchArgument,
-    ExecuteProcess,
-    OpaqueFunction,
-    Shutdown,
-)
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction
+from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 
 WORLD_NAME = 'portsmouth_nh_harbor'
@@ -40,11 +36,22 @@ def _launch_gazebo(context, *args, **kwargs):
             f'World SDF not found at {sdf_path}. '
             'Rebuild: colcon build --packages-select portsmouth_nh_gazebo'
         )
+
+    gz_args = f'{"-v4" if verbose else "-v1"} -r {sdf_path}'
+
     return [
-        ExecuteProcess(
-            cmd=['gz', 'sim', '-v4' if verbose else '-v1', sdf_path],
-            output='screen',
-            on_exit=Shutdown(),
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(
+                os.path.join(
+                    get_package_share_directory('ros_gz_sim'),
+                    'launch',
+                    'gz_sim.launch.py'
+                )
+            ),
+            launch_arguments={
+                'gz_args': gz_args,
+                'on_exit_shutdown': 'true',
+            }.items(),
         ),
     ]
 

--- a/portsmouth_nh_gazebo/launch/harbor_launch.py
+++ b/portsmouth_nh_gazebo/launch/harbor_launch.py
@@ -37,7 +37,11 @@ def _launch_gazebo(context, *args, **kwargs):
             'Rebuild: colcon build --packages-select portsmouth_nh_gazebo'
         )
 
-    gz_args = f'{"-v4" if verbose else "-v1"} -r {sdf_path}'
+    gz_args = (
+        f'{"-v4" if verbose else "-v1"} -r '
+        f'--physics-engine gz-physics-bullet-featherstone-plugin '
+        f'{sdf_path}'
+    )
 
     return [
         IncludeLaunchDescription(

--- a/portsmouth_nh_gazebo/launch/unh_pier_launch.py
+++ b/portsmouth_nh_gazebo/launch/unh_pier_launch.py
@@ -18,12 +18,8 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import (
-    DeclareLaunchArgument,
-    ExecuteProcess,
-    OpaqueFunction,
-    Shutdown,
-)
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction
+from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 
 WORLD_NAME = 'portsmouth_nh_unh_pier'
@@ -40,11 +36,26 @@ def _launch_gazebo(context, *args, **kwargs):
             f'World SDF not found at {sdf_path}. '
             'Rebuild: colcon build --packages-select portsmouth_nh_gazebo'
         )
+
+    gz_args = (
+        f'{"-v4" if verbose else "-v1"} -r '
+        f'--physics-engine gz-physics-bullet-featherstone-plugin '
+        f'{sdf_path}'
+    )
+
     return [
-        ExecuteProcess(
-            cmd=['gz', 'sim', '-v4' if verbose else '-v1', sdf_path],
-            output='screen',
-            on_exit=Shutdown(),
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(
+                os.path.join(
+                    get_package_share_directory('ros_gz_sim'),
+                    'launch',
+                    'gz_sim.launch.py'
+                )
+            ),
+            launch_arguments={
+                'gz_args': gz_args,
+                'on_exit_shutdown': 'true',
+            }.items(),
         ),
     ]
 


### PR DESCRIPTION
## Summary
- Extract Gazebo world + BEN spawn into standalone `gazebo_ben_launch.py`
- Update `gazebo_simulator_launch.py` to include the new launch file
- Convert `harbor_launch.py` and `unh_pier_launch.py` to use `ros_gz_sim` wrapper (sets `GZ_SIM_RESOURCE_PATH` and `GZ_SIM_SYSTEM_PLUGIN_PATH`)
- Add `--physics-engine gz-physics-bullet-featherstone-plugin` flag to world launchers (required for VRX buoyancy/wave forces)

## Test plan
- [x] Harbor world launches correctly with ros_gz_sim wrapper
- [x] Pier world launches correctly with ros_gz_sim wrapper
- [x] Ben spawns and is visible in GUI for both worlds
- [x] Buoyancy and waves work with bullet-featherstone physics engine
- [x] `gazebo_ben_launch.py` launches Gazebo + Ben standalone

Closes #46

---
**Authored-By**: `Claude Code Agent`
**Model**: `claude-opus-4-6`
