### PR TITLE
[PLAN] Add wave/buoyancy support to generated world SDFs

### DIFF
--- a/.agent/work-plans/PLAN_ISSUE-48.md
+++ b/.agent/work-plans/PLAN_ISSUE-48.md
@@ -1,0 +1,125 @@
+# Plan: Add wave/buoyancy support to generated world SDFs
+
+## Issue
+
+https://github.com/rolker/unh_marine_simulation/issues/48
+
+## Context
+
+Generated world SDFs (harbor, pier, isles of shoals, etc.) lack VRX wave visuals
+and wavefield parameters. BEN's `PolyhedraBuoyancyDrag` plugin subscribes to
+`/vrx/wavefield/parameters`, but nothing publishes that topic in the generated
+worlds. Users currently must manually patch the installed SDF after build.
+
+VRX packages (`vrx_gz`, `vrx_gazebo`) are already in the underlay. The
+`coast_waves` model provides Gerstner wave visuals via `libWaveVisual.so`, and
+`libPublisherPlugin.so` publishes wavefield parameters (direction, gain, period,
+steepness) on a configurable topic.
+
+The world generation pipeline is:
+1. YAML config (`portsmouth_nh_gazebo/config/*.yaml`)
+2. `build_world.py` reads YAML → builds CLI args
+3. `generate_world.py` orchestrates terrain/features/SDF generation
+4. `world_builder.py` fills `world_template.sdf.xml` placeholders
+
+## Approach
+
+1. **Add `{wave_models}` placeholder to `world_template.sdf.xml`** — Insert a new
+   placeholder between the water plane and feature models sections. This follows the
+   existing pattern (`{terrain_includes}`, `{s57_feature_models}`, etc.).
+
+2. **Add wave SDF generation to `world_builder.py`** — New function
+   `_build_wave_sdf(wave_config)` that generates:
+   - A `coast_waves` model `<include>` for VRX Gerstner wave visuals
+   - A `vrx::PublisherPlugin` world plugin publishing wavefield parameters
+
+   Parameters (from `wave_config` dict, with defaults):
+   - `gain` (default: `0.3`) — wave amplitude multiplier
+   - `period` (default: `5.0`) — wave period in seconds
+   - `direction` (default: `0.0`) — wave direction in degrees
+   - `steepness` (default: `0.0`) — Gerstner wave steepness
+   - `topic` (default: `/vrx/wavefield/parameters`) — parameter topic
+
+   Update `generate_world_sdf()` to accept a `wave_config` parameter and pass the
+   generated SDF to the template.
+
+3. **Add `--waves` CLI flag to `generate_world.py`** — A simple boolean flag that
+   enables wave generation with defaults. Individual wave parameters are not exposed
+   as CLI args (YAML config is the primary interface for per-world customization).
+   Pass `wave_config` through to `generate_world_sdf()`.
+
+4. **Add `waves` YAML config support to `build_world.py`** — Read optional `waves`
+   key from the YAML config. When present (either `waves: true` for defaults or a
+   mapping with parameter overrides), pass `--waves` to generate_world and propagate
+   parameter values.
+
+   YAML examples:
+   ```yaml
+   # Enable with defaults
+   waves: true
+
+   # Enable with custom parameters
+   waves:
+     gain: 0.5
+     period: 8.0
+     direction: 240.0
+   ```
+
+5. **Enable waves in all four Portsmouth NH configs** — Add `waves: true` to
+   `portsmouth.yaml`, `isles_of_shoals.yaml`, `portsmouth_to_isles.yaml`, and
+   `unh_pier.yaml`. Default parameters are appropriate for coastal New Hampshire.
+
+6. **Add test for wave SDF generation** — Extend `test_world_builder.py`:
+   - Test that wave config produces `coast_waves` include and PublisherPlugin
+   - Test that no wave content appears when wave_config is None (default)
+   - Test that custom parameters are reflected in the generated SDF
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/world_template.sdf.xml` | Add `{wave_models}` placeholder |
+| `marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/world_builder.py` | Add `_build_wave_sdf()`, update `generate_world_sdf()` signature |
+| `marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/generate_world.py` | Add `--waves` flag, pass wave_config to builder |
+| `portsmouth_nh_gazebo/scripts/build_world.py` | Read `waves` YAML config, pass `--waves` flag |
+| `portsmouth_nh_gazebo/config/portsmouth.yaml` | Add `waves: true` |
+| `portsmouth_nh_gazebo/config/isles_of_shoals.yaml` | Add `waves: true` |
+| `portsmouth_nh_gazebo/config/portsmouth_to_isles.yaml` | Add `waves: true` |
+| `portsmouth_nh_gazebo/config/unh_pier.yaml` | Add `waves: true` |
+| `marine_charts_to_gazebo_world/test/test_world_builder.py` | Add wave SDF tests |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| A change includes its consequences | Tests added for wave SDF generation. YAML configs updated alongside template changes. |
+| Only what's needed | Minimal addition: one template placeholder, one builder function, one CLI flag, one YAML key. No over-engineering of wave parameter CLI exposure. |
+| Improve incrementally | Single PR adds wave support without restructuring the generation pipeline. |
+| Test what breaks | Tests verify wave content presence/absence and parameter propagation — the regression-prone parts. |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0002 (Worktree isolation) | Yes | Working in `feature/issue-48` worktree |
+| ADR-0008 (ROS 2 conventions) | Watch | YAML config keys follow existing patterns (lowercase, underscores). No new ROS interfaces. |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `world_template.sdf.xml` | `world_builder.py` (new placeholder) | Yes |
+| `generate_world_sdf()` signature | All callers (`generate_world.py`) | Yes |
+| `generate_world.py` CLI args | `build_world.py` (YAML-to-CLI bridge) | Yes |
+| YAML config schema | `.agents/README.md` (if it documents config format) | No — minor, not currently documented there |
+
+## Open Questions
+
+- **Replace or augment the flat water plane?** The `coast_waves` model provides its
+  own wave mesh visual. Should the existing `water_plane` model be removed when waves
+  are enabled, or kept as a fallback? The VRX wave mesh may not cover the full world
+  extent for large worlds. Recommend: keep both; the wave mesh overlays the flat plane.
+
+## Estimated Scope
+
+Single PR. All changes are in two packages within the same repo.

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/generate_world.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/generate_world.py
@@ -213,6 +213,36 @@ def parse_args(argv=None):
         "is adjusted automatically to stay under this cap. "
         "Set to 0 to disable trees. Default: 500.",
     )
+    parser.add_argument(
+        "--waves",
+        action="store_true",
+        help="Add VRX wave visuals (coast_waves) and a wavefield parameter "
+        "publisher to the world. Required for buoyancy simulation.",
+    )
+    parser.add_argument(
+        "--wave-gain",
+        type=float,
+        default=None,
+        help="Wave amplitude gain (default: 0.3). Requires --waves.",
+    )
+    parser.add_argument(
+        "--wave-period",
+        type=float,
+        default=None,
+        help="Wave period in seconds (default: 5.0). Requires --waves.",
+    )
+    parser.add_argument(
+        "--wave-direction",
+        type=float,
+        default=None,
+        help="Wave direction in degrees (default: 0.0). Requires --waves.",
+    )
+    parser.add_argument(
+        "--wave-steepness",
+        type=float,
+        default=None,
+        help="Gerstner wave steepness (default: 0.0). Requires --waves.",
+    )
     return parser.parse_args(argv)
 
 
@@ -535,6 +565,17 @@ def main(argv=None):
         camera_config["direction"] = args.camera_direction
 
     water_x, water_y = _bbox_size_meters(bbox)
+    wave_config = None
+    if args.waves:
+        wave_config = {}
+        if args.wave_gain is not None:
+            wave_config["gain"] = args.wave_gain
+        if args.wave_period is not None:
+            wave_config["period"] = args.wave_period
+        if args.wave_direction is not None:
+            wave_config["direction"] = args.wave_direction
+        if args.wave_steepness is not None:
+            wave_config["steepness"] = args.wave_steepness
     print("Generating world SDF...")
     sdf_path = generate_world_sdf(
         world_name=args.world_name,
@@ -547,6 +588,7 @@ def main(argv=None):
         osm_feature_models=osm_feature_sdf,
         water_size_x=water_x,
         water_size_y=water_y,
+        wave_config=wave_config,
     )
     print(f"  World SDF saved to {sdf_path}")
 

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/generate_world.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/generate_world.py
@@ -243,6 +243,12 @@ def parse_args(argv=None):
         default=None,
         help="Gerstner wave steepness (default: 0.0). Requires --waves.",
     )
+    parser.add_argument(
+        "--wave-topic",
+        default=None,
+        help="Wavefield parameter topic "
+        "(default: /vrx/wavefield/parameters). Requires --waves.",
+    )
     return parser.parse_args(argv)
 
 
@@ -576,6 +582,8 @@ def main(argv=None):
             wave_config["direction"] = args.wave_direction
         if args.wave_steepness is not None:
             wave_config["steepness"] = args.wave_steepness
+        if args.wave_topic is not None:
+            wave_config["topic"] = args.wave_topic
     print("Generating world SDF...")
     sdf_path = generate_world_sdf(
         world_name=args.world_name,

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/generate_world.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/generate_world.py
@@ -571,6 +571,11 @@ def main(argv=None):
         camera_config["direction"] = args.camera_direction
 
     water_x, water_y = _bbox_size_meters(bbox)
+    wave_opts = [args.wave_gain, args.wave_period, args.wave_direction,
+                 args.wave_steepness, args.wave_topic]
+    if not args.waves and any(v is not None for v in wave_opts):
+        print("Error: --wave-* options require --waves", file=sys.stderr)
+        return 1
     wave_config = None
     if args.waves:
         wave_config = {}

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/world_builder.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/world_builder.py
@@ -16,6 +16,7 @@
 
 import math
 import os
+import re
 
 
 _TEMPLATE_PATH = os.path.join(
@@ -121,6 +122,33 @@ def _build_terrain_includes(heightmap_info):
     return '\n'.join(includes)
 
 
+def _build_static_water_plane(size_x, size_y):
+    """Build SDF for a static semi-transparent water plane."""
+    return (
+        '    <!-- Water surface slightly above z=0 to reduce z-fighting '
+        'at shoreline -->\n'
+        '    <model name="water_plane">\n'
+        '      <static>true</static>\n'
+        '      <link name="link">\n'
+        '        <visual name="water_visual">\n'
+        '          <pose>0 0 0.05 0 0 0</pose>\n'
+        '          <geometry>\n'
+        '            <plane>\n'
+        '              <normal>0 0 1</normal>\n'
+        f'              <size>{size_x:.0f} {size_y:.0f}</size>\n'
+        '            </plane>\n'
+        '          </geometry>\n'
+        '          <material>\n'
+        '            <ambient>0.0 0.05 0.3 0.8</ambient>\n'
+        '            <diffuse>0.0 0.1 0.5 0.8</diffuse>\n'
+        '            <specular>0.1 0.1 0.1 0.5</specular>\n'
+        '          </material>\n'
+        '        </visual>\n'
+        '      </link>\n'
+        '    </model>'
+    )
+
+
 # Default wavefield parameters matching VRX conventions.
 _WAVE_DEFAULTS = {
     "gain": 0.3,
@@ -143,6 +171,8 @@ def _build_wave_sdf(wave_config):
     """
     cfg = {**_WAVE_DEFAULTS, **(wave_config or {})}
     topic = cfg["topic"]
+    if not re.fullmatch(r'[~/a-zA-Z0-9_][/a-zA-Z0-9_]*', topic):
+        raise ValueError(f"Invalid ROS topic for wavefield publisher: {topic!r}")
 
     lines = [
         '    <!-- VRX wave visuals (Gerstner waves) -->',
@@ -196,10 +226,10 @@ def generate_world_sdf(
     - DART physics (4ms step)
     - Standard Gazebo system plugins
     - Terrain heightmap model(s)
-    - Semi-transparent water surface plane
+    - Water surface: VRX wave visuals when wave_config is set,
+      otherwise a static semi-transparent plane
     - Scene with sky and lighting
     - Optional S57/OSM chart feature models (buildings, buoys, etc.)
-    - Optional VRX wave visuals and wavefield parameter publisher
 
     Args:
         world_name: Name for the world (used in filename and SDF).
@@ -217,7 +247,8 @@ def generate_world_sdf(
             heightmap_info size.
         wave_config: optional dict with wave parameter overrides. When not
             None, VRX coast_waves visuals and a wavefield PublisherPlugin
-            are added. Keys: gain, period, direction, steepness, topic.
+            replace the static water plane. Keys: gain, period, direction,
+            steepness, topic.
 
     Returns:
         Path to the generated SDF file.
@@ -241,20 +272,22 @@ def generate_world_sdf(
         template = f.read()
 
     terrain_includes = _build_terrain_includes(heightmap_info)
-    wave_models = _build_wave_sdf(wave_config) if wave_config is not None else ""
+
+    if wave_config is not None:
+        water_surface = _build_wave_sdf(wave_config)
+    else:
+        water_surface = _build_static_water_plane(wx, wy)
 
     sdf_content = template.format(
         world_name=world_name,
         center_lat=center_lat,
         center_lon=center_lon,
-        water_size_x=wx,
-        water_size_y=wy,
         terrain_includes=terrain_includes,
         camera_pose=camera_pose,
         camera_far=camera_far,
+        water_surface=water_surface,
         s57_feature_models=s57_feature_models,
         osm_feature_models=osm_feature_models,
-        wave_models=wave_models,
     )
 
     sdf_path = os.path.join(output_dir, f"{world_name}.sdf")

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/world_builder.py
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/world_builder.py
@@ -121,6 +121,61 @@ def _build_terrain_includes(heightmap_info):
     return '\n'.join(includes)
 
 
+# Default wavefield parameters matching VRX conventions.
+_WAVE_DEFAULTS = {
+    "gain": 0.3,
+    "period": 5.0,
+    "direction": 0.0,
+    "steepness": 0.0,
+    "topic": "/vrx/wavefield/parameters",
+}
+
+
+def _build_wave_sdf(wave_config):
+    """Build SDF for VRX wave visuals and wavefield parameter publisher.
+
+    Args:
+        wave_config: dict with optional keys 'gain', 'period', 'direction',
+            'steepness', 'topic'. Missing keys use defaults.
+
+    Returns:
+        String of SDF XML (coast_waves include + PublisherPlugin).
+    """
+    cfg = {**_WAVE_DEFAULTS, **(wave_config or {})}
+    topic = cfg["topic"]
+
+    lines = [
+        '    <!-- VRX wave visuals (Gerstner waves) -->',
+        '    <include>',
+        '      <uri>coast_waves</uri>',
+        '    </include>',
+        '',
+        '    <!-- Wavefield parameter publisher for buoyancy plugins -->',
+        '    <plugin filename="libPublisherPlugin.so"',
+        '            name="vrx::PublisherPlugin">',
+        f'      <message type="gz.msgs.Param" topic="{topic}"',
+        '               every="2.0">',
+    ]
+
+    for key in ("direction", "gain", "period", "steepness"):
+        lines.extend([
+            '        params {',
+            f'          key: "{key}"',
+            '          value {',
+            '            type: DOUBLE',
+            f'            double_value: {cfg[key]}',
+            '          }',
+            '        }',
+        ])
+
+    lines.extend([
+        '      </message>',
+        '    </plugin>',
+    ])
+
+    return '\n'.join(lines)
+
+
 def generate_world_sdf(
     world_name: str,
     center_lat: float,
@@ -132,6 +187,7 @@ def generate_world_sdf(
     osm_feature_models: str = "",
     water_size_x: float = 0.0,
     water_size_y: float = 0.0,
+    wave_config: dict = None,
 ) -> str:
     """Generate a complete Gazebo Harmonic world SDF file.
 
@@ -143,6 +199,7 @@ def generate_world_sdf(
     - Semi-transparent water surface plane
     - Scene with sky and lighting
     - Optional S57/OSM chart feature models (buildings, buoys, etc.)
+    - Optional VRX wave visuals and wavefield parameter publisher
 
     Args:
         world_name: Name for the world (used in filename and SDF).
@@ -158,6 +215,9 @@ def generate_world_sdf(
             heightmap_info size.
         water_size_y: Override water plane height (meters). If 0, uses
             heightmap_info size.
+        wave_config: optional dict with wave parameter overrides. When not
+            None, VRX coast_waves visuals and a wavefield PublisherPlugin
+            are added. Keys: gain, period, direction, steepness, topic.
 
     Returns:
         Path to the generated SDF file.
@@ -181,6 +241,7 @@ def generate_world_sdf(
         template = f.read()
 
     terrain_includes = _build_terrain_includes(heightmap_info)
+    wave_models = _build_wave_sdf(wave_config) if wave_config is not None else ""
 
     sdf_content = template.format(
         world_name=world_name,
@@ -193,6 +254,7 @@ def generate_world_sdf(
         camera_far=camera_far,
         s57_feature_models=s57_feature_models,
         osm_feature_models=osm_feature_models,
+        wave_models=wave_models,
     )
 
     sdf_path = os.path.join(output_dir, f"{world_name}.sdf")

--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/world_template.sdf.xml
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/world_template.sdf.xml
@@ -237,6 +237,8 @@
       </link>
     </model>
 
+{wave_models}
+
 {s57_feature_models}
 
 {osm_feature_models}

--- a/marine_charts_to_gazebo_world/test/test_world_builder.py
+++ b/marine_charts_to_gazebo_world/test/test_world_builder.py
@@ -256,6 +256,11 @@ class TestWaveSdf:
         assert "/custom/waves" in sdf
         assert "/vrx/wavefield/parameters" not in sdf
 
+    def test_build_wave_sdf_invalid_topic(self):
+        """Invalid topic should raise ValueError."""
+        with pytest.raises(ValueError, match="Invalid ROS topic"):
+            _build_wave_sdf({"topic": 'bad"topic<xml>'})
+
     def test_waves_valid_xml(self):
         """World with waves should still be valid XML."""
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/marine_charts_to_gazebo_world/test/test_world_builder.py
+++ b/marine_charts_to_gazebo_world/test/test_world_builder.py
@@ -20,7 +20,10 @@ import xml.etree.ElementTree as ET
 
 import pytest
 
-from marine_charts_to_gazebo_world.world_builder import generate_world_sdf
+from marine_charts_to_gazebo_world.world_builder import (
+    _build_wave_sdf,
+    generate_world_sdf,
+)
 
 
 class TestGenerateWorldSdf:
@@ -174,3 +177,95 @@ class TestGenerateWorldSdf:
             tree = ET.parse(sdf_path)
             root = tree.getroot()
             assert root.tag == "sdf"
+
+
+class TestWaveSdf:
+    """Tests for wave/buoyancy SDF generation."""
+
+    _HEIGHTMAP = {
+        "model_name": "test_terrain",
+        "size_x": 1000.0,
+        "size_y": 1000.0,
+        "size_z": 50.0,
+        "pos_z": -30.0,
+        "min_elevation": -30.0,
+        "max_elevation": 20.0,
+    }
+
+    def test_no_waves_by_default(self):
+        """Without wave_config, no wave content should appear."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            sdf_path = generate_world_sdf(
+                world_name="no_waves",
+                center_lat=43.075,
+                center_lon=-70.71,
+                output_dir=tmpdir,
+                heightmap_info=self._HEIGHTMAP,
+            )
+            with open(sdf_path) as f:
+                content = f.read()
+            assert "coast_waves" not in content
+            assert "PublisherPlugin" not in content
+
+    def test_waves_with_defaults(self):
+        """wave_config={} should produce coast_waves and PublisherPlugin."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            sdf_path = generate_world_sdf(
+                world_name="with_waves",
+                center_lat=43.075,
+                center_lon=-70.71,
+                output_dir=tmpdir,
+                heightmap_info=self._HEIGHTMAP,
+                wave_config={},
+            )
+            with open(sdf_path) as f:
+                content = f.read()
+            assert "coast_waves" in content
+            assert "vrx::PublisherPlugin" in content
+            assert "/vrx/wavefield/parameters" in content
+            # Default values
+            assert 'double_value: 0.3' in content  # gain
+            assert 'double_value: 5.0' in content  # period
+
+    def test_waves_custom_parameters(self):
+        """Custom wave parameters should appear in generated SDF."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            sdf_path = generate_world_sdf(
+                world_name="custom_waves",
+                center_lat=43.075,
+                center_lon=-70.71,
+                output_dir=tmpdir,
+                heightmap_info=self._HEIGHTMAP,
+                wave_config={"gain": 0.5, "period": 8.0, "direction": 240.0},
+            )
+            with open(sdf_path) as f:
+                content = f.read()
+            assert 'double_value: 0.5' in content
+            assert 'double_value: 8.0' in content
+            assert 'double_value: 240.0' in content
+
+    def test_build_wave_sdf_contains_all_params(self):
+        """_build_wave_sdf should include all four wavefield parameters."""
+        sdf = _build_wave_sdf({})
+        for key in ("direction", "gain", "period", "steepness"):
+            assert f'key: "{key}"' in sdf
+
+    def test_build_wave_sdf_custom_topic(self):
+        """Custom topic should be used in the PublisherPlugin."""
+        sdf = _build_wave_sdf({"topic": "/custom/waves"})
+        assert "/custom/waves" in sdf
+        assert "/vrx/wavefield/parameters" not in sdf
+
+    def test_waves_valid_xml(self):
+        """World with waves should still be valid XML."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            sdf_path = generate_world_sdf(
+                world_name="waves_xml",
+                center_lat=43.075,
+                center_lon=-70.71,
+                output_dir=tmpdir,
+                heightmap_info=self._HEIGHTMAP,
+                wave_config={"gain": 0.7},
+            )
+            tree = ET.parse(sdf_path)
+            assert tree.getroot().tag == "sdf"

--- a/portsmouth_nh_gazebo/config/isles_of_shoals.yaml
+++ b/portsmouth_nh_gazebo/config/isles_of_shoals.yaml
@@ -9,3 +9,5 @@ world_name: portsmouth_nh_isles_of_shoals
 grid_power: 10   # 1025x1025
 
 osm: true
+
+waves: true

--- a/portsmouth_nh_gazebo/config/portsmouth.yaml
+++ b/portsmouth_nh_gazebo/config/portsmouth.yaml
@@ -10,3 +10,5 @@ world_name: portsmouth_nh_harbor
 grid_power: 10   # 1025x1025 (~3.2 m/cell)
 
 osm: true
+
+waves: true

--- a/portsmouth_nh_gazebo/config/portsmouth_to_isles.yaml
+++ b/portsmouth_nh_gazebo/config/portsmouth_to_isles.yaml
@@ -30,3 +30,5 @@ tiles:
     grid_power: 10   # 1025x1025
 
 osm: true
+
+waves: true

--- a/portsmouth_nh_gazebo/config/unh_pier.yaml
+++ b/portsmouth_nh_gazebo/config/unh_pier.yaml
@@ -9,3 +9,5 @@ world_name: portsmouth_nh_unh_pier
 grid_power: 10   # 1025x1025 (~0.35 m/cell for this small area)
 
 osm: true
+
+waves: true

--- a/portsmouth_nh_gazebo/scripts/build_world.py
+++ b/portsmouth_nh_gazebo/scripts/build_world.py
@@ -148,7 +148,7 @@ def main():
     if waves:
         gen_args.append('--waves')
         if isinstance(waves, dict):
-            for key in ('gain', 'period', 'direction', 'steepness'):
+            for key in ('gain', 'period', 'direction', 'steepness', 'topic'):
                 if key in waves:
                     gen_args.extend([f'--wave-{key}', str(waves[key])])
 

--- a/portsmouth_nh_gazebo/scripts/build_world.py
+++ b/portsmouth_nh_gazebo/scripts/build_world.py
@@ -145,7 +145,7 @@ def main():
     # Wave/buoyancy support (optional)
     # Accept waves: true (defaults) or waves: {gain: ..., period: ...}
     waves = config.get('waves')
-    if waves:
+    if waves is not None and waves is not False:
         gen_args.append('--waves')
         if isinstance(waves, dict):
             for key in ('gain', 'period', 'direction', 'steepness', 'topic'):

--- a/portsmouth_nh_gazebo/scripts/build_world.py
+++ b/portsmouth_nh_gazebo/scripts/build_world.py
@@ -142,6 +142,16 @@ def main():
     if config.get('osm_matching'):
         gen_args.append('--osm-matching')
 
+    # Wave/buoyancy support (optional)
+    # Accept waves: true (defaults) or waves: {gain: ..., period: ...}
+    waves = config.get('waves')
+    if waves:
+        gen_args.append('--waves')
+        if isinstance(waves, dict):
+            for key in ('gain', 'period', 'direction', 'steepness'):
+                if key in waves:
+                    gen_args.extend([f'--wave-{key}', str(waves[key])])
+
     # ETOPO bathymetry (optional)
     if config.get('fetch_etopo'):
         gen_args.append('--fetch-etopo')


### PR DESCRIPTION
Closes #48

# Plan: Add wave/buoyancy support to generated world SDFs

## Issue

https://github.com/rolker/unh_marine_simulation/issues/48

## Context

Generated world SDFs (harbor, pier, isles of shoals, etc.) lack VRX wave visuals
and wavefield parameters. BEN's `PolyhedraBuoyancyDrag` plugin subscribes to
`/vrx/wavefield/parameters`, but nothing publishes that topic in the generated
worlds. Users currently must manually patch the installed SDF after build.

VRX packages (`vrx_gz`, `vrx_gazebo`) are already in the underlay. The
`coast_waves` model provides Gerstner wave visuals via `libWaveVisual.so`, and
`libPublisherPlugin.so` publishes wavefield parameters (direction, gain, period,
steepness) on a configurable topic.

The world generation pipeline is:
1. YAML config (`portsmouth_nh_gazebo/config/*.yaml`)
2. `build_world.py` reads YAML → builds CLI args
3. `generate_world.py` orchestrates terrain/features/SDF generation
4. `world_builder.py` fills `world_template.sdf.xml` placeholders

## Approach

1. **Add `{wave_models}` placeholder to `world_template.sdf.xml`** — Insert a new
   placeholder between the water plane and feature models sections. This follows the
   existing pattern (`{terrain_includes}`, `{s57_feature_models}`, etc.).

2. **Add wave SDF generation to `world_builder.py`** — New function
   `_build_wave_sdf(wave_config)` that generates:
   - A `coast_waves` model `<include>` for VRX Gerstner wave visuals
   - A `vrx::PublisherPlugin` world plugin publishing wavefield parameters

   Parameters (from `wave_config` dict, with defaults):
   - `gain` (default: `0.3`) — wave amplitude multiplier
   - `period` (default: `5.0`) — wave period in seconds
   - `direction` (default: `0.0`) — wave direction in degrees
   - `steepness` (default: `0.0`) — Gerstner wave steepness
   - `topic` (default: `/vrx/wavefield/parameters`) — parameter topic

   Update `generate_world_sdf()` to accept a `wave_config` parameter and pass the
   generated SDF to the template.

3. **Add `--waves` CLI flag to `generate_world.py`** — A simple boolean flag that
   enables wave generation with defaults. Individual wave parameters are not exposed
   as CLI args (YAML config is the primary interface for per-world customization).
   Pass `wave_config` through to `generate_world_sdf()`.

4. **Add `waves` YAML config support to `build_world.py`** — Read optional `waves`
   key from the YAML config. When present (either `waves: true` for defaults or a
   mapping with parameter overrides), pass `--waves` to generate_world and propagate
   parameter values.

   YAML examples:
   ```yaml
   # Enable with defaults
   waves: true

   # Enable with custom parameters
   waves:
     gain: 0.5
     period: 8.0
     direction: 240.0
   ```

5. **Enable waves in all four Portsmouth NH configs** — Add `waves: true` to
   `portsmouth.yaml`, `isles_of_shoals.yaml`, `portsmouth_to_isles.yaml`, and
   `unh_pier.yaml`. Default parameters are appropriate for coastal New Hampshire.

6. **Add test for wave SDF generation** — Extend `test_world_builder.py`:
   - Test that wave config produces `coast_waves` include and PublisherPlugin
   - Test that no wave content appears when wave_config is None (default)
   - Test that custom parameters are reflected in the generated SDF

## Files to Change

| File | Change |
|------|--------|
| `marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/world_template.sdf.xml` | Add `{wave_models}` placeholder |
| `marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/world_builder.py` | Add `_build_wave_sdf()`, update `generate_world_sdf()` signature |
| `marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/generate_world.py` | Add `--waves` flag, pass wave_config to builder |
| `portsmouth_nh_gazebo/scripts/build_world.py` | Read `waves` YAML config, pass `--waves` flag |
| `portsmouth_nh_gazebo/config/portsmouth.yaml` | Add `waves: true` |
| `portsmouth_nh_gazebo/config/isles_of_shoals.yaml` | Add `waves: true` |
| `portsmouth_nh_gazebo/config/portsmouth_to_isles.yaml` | Add `waves: true` |
| `portsmouth_nh_gazebo/config/unh_pier.yaml` | Add `waves: true` |
| `marine_charts_to_gazebo_world/test/test_world_builder.py` | Add wave SDF tests |

## Principles Self-Check

| Principle | Consideration |
|---|---|
| A change includes its consequences | Tests added for wave SDF generation. YAML configs updated alongside template changes. |
| Only what's needed | Minimal addition: one template placeholder, one builder function, one CLI flag, one YAML key. No over-engineering of wave parameter CLI exposure. |
| Improve incrementally | Single PR adds wave support without restructuring the generation pipeline. |
| Test what breaks | Tests verify wave content presence/absence and parameter propagation — the regression-prone parts. |

## ADR Compliance

| ADR | Triggered | How addressed |
|---|---|---|
| ADR-0002 (Worktree isolation) | Yes | Working in `feature/issue-48` worktree |
| ADR-0008 (ROS 2 conventions) | Watch | YAML config keys follow existing patterns (lowercase, underscores). No new ROS interfaces. |

## Consequences

| If we change... | Also update... | Included in plan? |
|---|---|---|
| `world_template.sdf.xml` | `world_builder.py` (new placeholder) | Yes |
| `generate_world_sdf()` signature | All callers (`generate_world.py`) | Yes |
| `generate_world.py` CLI args | `build_world.py` (YAML-to-CLI bridge) | Yes |
| YAML config schema | `.agents/README.md` (if it documents config format) | No — minor, not currently documented there |

## Open Questions

- **Replace or augment the flat water plane?** The `coast_waves` model provides its
  own wave mesh visual. Should the existing `water_plane` model be removed when waves
  are enabled, or kept as a fallback? The VRX wave mesh may not cover the full world
  extent for large worlds. Recommend: keep both; the wave mesh overlays the flat plane.

## Estimated Scope

Single PR. All changes are in two packages within the same repo.
