### PR TITLE
Fix world template placeholder mismatch from PR #49

### DIFF
--- a/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/world_template.sdf.xml
+++ b/marine_charts_to_gazebo_world/marine_charts_to_gazebo_world/world_template.sdf.xml
@@ -216,28 +216,7 @@
     <!-- Generated terrain -->
 {terrain_includes}
 
-    <!-- Water surface slightly above z=0 to reduce z-fighting at shoreline -->
-    <model name="water_plane">
-      <static>true</static>
-      <link name="link">
-        <visual name="water_visual">
-          <pose>0 0 0.05 0 0 0</pose>
-          <geometry>
-            <plane>
-              <normal>0 0 1</normal>
-              <size>{water_size_x:.0f} {water_size_y:.0f}</size>
-            </plane>
-          </geometry>
-          <material>
-            <ambient>0.0 0.05 0.3 0.8</ambient>
-            <diffuse>0.0 0.1 0.5 0.8</diffuse>
-            <specular>0.1 0.1 0.1 0.5</specular>
-          </material>
-        </visual>
-      </link>
-    </model>
-
-{wave_models}
+{water_surface}
 
 {s57_feature_models}
 


### PR DESCRIPTION
## Summary

- Replace inline `water_plane` model and `{wave_models}` placeholder in `world_template.sdf.xml` with a single `{water_surface}` placeholder
- Fixes `KeyError: 'water_size_x'` that breaks all world generation after PR #49

The template refactor was locally present in the issue-48 worktree but was not committed as part of PR #49, leaving the template out of sync with `world_builder.py` which now passes `water_surface` instead of `water_size_x`/`water_size_y`/`wave_models`.

Closes #50

## Test plan

- [x] `marine_charts_to_gazebo_world` tests pass (82/82)
- [x] `portsmouth_nh_gazebo` builds successfully (all 4 worlds generated)

---
**Authored-By**: Claude Code Agent
**Model**: Claude Opus 4.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)
