### PR TITLE
Revert harbor/pier launchers from Bullet to DART

### DIFF
--- a/portsmouth_nh_gazebo/launch/harbor_launch.py
+++ b/portsmouth_nh_gazebo/launch/harbor_launch.py
@@ -37,11 +37,7 @@ def _launch_gazebo(context, *args, **kwargs):
             'Rebuild: colcon build --packages-select portsmouth_nh_gazebo'
         )
 
-    gz_args = (
-        f'{"-v4" if verbose else "-v1"} -r '
-        f'--physics-engine gz-physics-bullet-featherstone-plugin '
-        f'{sdf_path}'
-    )
+    gz_args = f'{"-v4" if verbose else "-v1"} -r {sdf_path}'
 
     return [
         IncludeLaunchDescription(

--- a/portsmouth_nh_gazebo/launch/unh_pier_launch.py
+++ b/portsmouth_nh_gazebo/launch/unh_pier_launch.py
@@ -37,11 +37,7 @@ def _launch_gazebo(context, *args, **kwargs):
             'Rebuild: colcon build --packages-select portsmouth_nh_gazebo'
         )
 
-    gz_args = (
-        f'{"-v4" if verbose else "-v1"} -r '
-        f'--physics-engine gz-physics-bullet-featherstone-plugin '
-        f'{sdf_path}'
-    )
+    gz_args = f'{"-v4" if verbose else "-v1"} -r {sdf_path}'
 
     return [
         IncludeLaunchDescription(


### PR DESCRIPTION
## Summary

- Remove `--physics-engine gz-physics-bullet-featherstone-plugin` from `harbor_launch.py` and `unh_pier_launch.py`
- Reverts to default DART physics engine which correctly supports polyline collision geometry used by building features

Bullet Featherstone (added in PR #47) doesn't support polyline geometry, causing buildings and other S57 features not to render. The VRX wavefield parameter publisher (`PublisherPlugin`) is physics-engine independent, so wave parameters continue to be published for buoyancy plugins.

Closes #52

## Test plan

- [x] Harbor world launches with DART and buildings are visible
- [ ] Verify wave visuals still appear
- [ ] Verify wavefield parameters are published (`ros2 topic echo /vrx/wavefield/parameters`)

---
**Authored-By**: Claude Code Agent
**Model**: Claude Opus 4.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)
