### PR TITLE
Add optional bag recording to simulator launch

### DIFF
--- a/marine_simulation/config/sim_bag_recording.yaml
+++ b/marine_simulation/config/sim_bag_recording.yaml
@@ -1,0 +1,38 @@
+/**:
+  ros__parameters:
+    record:
+      all_topics: false
+      topics:
+      # Mission manager / autonomy
+      - /ben/marine/heartbeat
+      - /ben/marine/status/mission_manager
+      - /ben/marine/response
+      - /marine/platforms
+      # Behavior tree
+      - /ben/behavior_tree_log
+      - /ben/run_tasks/_action/status
+      - /ben/run_tasks/_action/send_goal
+      # Nav2 actions
+      - /ben/follow_path/_action/status
+      - /ben/compute_path_through_poses/_action/status
+      - /ben/hover/_action/status
+      # Planning and control
+      - /ben/plan
+      - /ben/path_follower_visualization
+      - /ben/hover_visualization
+      - /ben/collision_monitor_state
+      - /ben/local_costmap/published_footprint
+      - /ben/piloting_mode/autonomous/cmd_vel
+      # Position / velocity / state
+      - /ben/odom
+      - /ben/sensors/nav/position
+      - /ben/sensors/nav/orientation
+      - /ben/sensors/nav/velocity
+      # TF and diagnostics
+      - /tf
+      - /tf_static
+      - /rosout
+      - /diagnostics
+    storage:
+      max_bagfile_duration: 300
+      storage_preset_profile: zstd_fast

--- a/marine_simulation/launch/simulator_launch.py
+++ b/marine_simulation/launch/simulator_launch.py
@@ -28,6 +28,8 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 
+import datetime
+
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.actions import GroupAction
@@ -39,12 +41,15 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch.substitutions import PathJoinSubstitution
 from launch.substitutions import TextSubstitution
+from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
     background_chart = LaunchConfiguration('background_chart')
     enable_bridge = LaunchConfiguration('enable_bridge')
+    record_bag = LaunchConfiguration('record_bag')
+    bag_directory = LaunchConfiguration('bag_directory')
 
     background_chart_arg = DeclareLaunchArgument(
         'background_chart', default_value=PathJoinSubstitution(
@@ -54,6 +59,21 @@ def generate_launch_description():
 
     enable_bridge_arg = DeclareLaunchArgument(
         'enable_bridge', default_value=TextSubstitution(text='false')
+    )
+
+    record_bag_arg = DeclareLaunchArgument(
+        'record_bag', default_value=TextSubstitution(text='true'),
+        description='Enable rosbag recording of simulation telemetry'
+    )
+
+    datetime_str = datetime.datetime.now().strftime('%Y-%m-%dT%H.%M.%S')
+    default_bag_dir = PathJoinSubstitution([
+        TextSubstitution(text='~/data/logs/sim/'),
+        TextSubstitution(text=datetime_str),
+    ])
+    bag_directory_arg = DeclareLaunchArgument(
+        'bag_directory', default_value=default_bag_dir,
+        description='Output directory for bag recording'
     )
 
     launch_sim_robot_include = IncludeLaunchDescription(
@@ -113,13 +133,32 @@ def generate_launch_description():
         ]
     )
 
+    bag_recorder = Node(
+        package='rosbag2_transport',
+        executable='recorder',
+        name='sim_logger',
+        condition=IfCondition(record_bag),
+        parameters=[
+            PathJoinSubstitution([
+                FindPackageShare('marine_simulation'),
+                'config',
+                'sim_bag_recording.yaml'
+            ]),
+            {'storage.uri': bag_directory},
+        ],
+        emulate_tty=True
+    )
+
     return LaunchDescription([
         background_chart_arg,
         enable_bridge_arg,
+        record_bag_arg,
+        bag_directory_arg,
         LogInfo(
             condition=IfCondition(enable_bridge),
             msg=TextSubstitution(text='Bridge enabled')
         ),
         launch_sim_robot_include,
-        launch_sim_operator_group
+        launch_sim_operator_group,
+        bag_recorder,
     ])

--- a/marine_simulation/launch/simulator_launch.py
+++ b/marine_simulation/launch/simulator_launch.py
@@ -40,6 +40,7 @@ from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch.substitutions import PathJoinSubstitution
+from launch.substitutions import EnvironmentVariable
 from launch.substitutions import TextSubstitution
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
@@ -68,7 +69,8 @@ def generate_launch_description():
 
     datetime_str = datetime.datetime.now().strftime('%Y-%m-%dT%H.%M.%S')
     default_bag_dir = PathJoinSubstitution([
-        TextSubstitution(text='~/data/logs/sim/'),
+        EnvironmentVariable('HOME'),
+        TextSubstitution(text='data/logs/sim'),
         TextSubstitution(text=datetime_str),
     ])
     bag_directory_arg = DeclareLaunchArgument(

--- a/marine_simulation/package.xml
+++ b/marine_simulation/package.xml
@@ -25,6 +25,7 @@
   <exec_depend>ben_project11</exec_depend>
   <exec_depend>camp</exec_depend>
   <exec_depend>lifecycle_msgs</exec_depend>
+  <exec_depend>rosbag2_transport</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
 


### PR DESCRIPTION
## Summary

- Add rosbag2 recorder to `simulator_launch.py` for post-run analysis
- Record mission manager heartbeat, BT log, nav2 action status, position, TF, diagnostics
- Output to `~/data/logs/sim/<timestamp>` by default
- Configurable: `record_bag:=false` to disable, `bag_directory:=<path>` to override

Closes #56

## Usage

```bash
# Default: records to ~/data/logs/sim/<timestamp>
ros2 launch marine_simulation simulator_launch.py

# Disable recording
ros2 launch marine_simulation simulator_launch.py record_bag:=false

# Custom output directory
ros2 launch marine_simulation simulator_launch.py bag_directory:=/tmp/my_test
```

## Test plan

- [ ] Build `marine_simulation`
- [ ] Launch simulator, verify bag files appear in `~/data/logs/sim/`
- [ ] Verify topics are recorded: `ros2 bag info <bag_dir>`
- [ ] Verify `record_bag:=false` disables recording

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
