### PR TITLE
fix(launch): remove duplicate sea_surface_estimator from sim_robot_launch

### DIFF
--- a/marine_simulation/launch/sim_robot_launch.py
+++ b/marine_simulation/launch/sim_robot_launch.py
@@ -39,15 +39,12 @@ from launch.substitutions import LaunchConfiguration
 from launch.substitutions import PathJoinSubstitution
 from launch.substitutions import PythonExpression
 from launch.substitutions import TextSubstitution
-from launch_ros.actions import LifecycleNode
-from launch_ros.actions import LifecycleTransition
 from launch_ros.actions import Node
 from launch_ros.actions import PushROSNamespace
 from launch_ros.actions import SetParameter
 from launch_ros.actions import SetParametersFromFile
 from launch_ros.actions import SetRemap
 from launch_ros.substitutions import FindPackageShare
-from lifecycle_msgs.msg import Transition
 
 
 def generate_launch_description():
@@ -345,44 +342,6 @@ def generate_launch_description():
                         ]
                     )
                 ]
-            ),
-            # sea_surface_estimator: estimates tide from odom z for
-            # the map_tide frame used by depth/costmap adjustments
-            GroupAction(
-                actions=[
-                    PushROSNamespace(namespace),
-                    LifecycleNode(
-                        package='mru_transform',
-                        executable='sea_surface_estimator',
-                        name='sea_surface_estimator',
-                        namespace='',
-                        respawn=True,
-                        respawn_delay=2,
-                        emulate_tty=True,
-                        parameters=[{
-                            'sea_surface_frame': PythonExpression(
-                                expression=[
-                                    '"', namespace, '/map_tide"'
-                                ]
-                            ),
-                        }],
-                    ),
-                    LifecycleTransition(
-                        lifecycle_node_names=(
-                            PythonExpression(
-                                expression=[
-                                    '"/',
-                                    namespace,
-                                    '/sea_surface_estimator"',
-                                ],
-                            ),
-                        ),
-                        transition_ids=(
-                            Transition.TRANSITION_CONFIGURE,
-                            Transition.TRANSITION_ACTIVATE,
-                        ),
-                    ),
-                ],
             ),
         ],
         condition=UnlessCondition(no_sim),


### PR DESCRIPTION
## Summary

- Delete the redundant `sea_surface_estimator` `GroupAction` block (lines 349-386) from `marine_simulation/launch/sim_robot_launch.py`.
- The same node was already being launched by `ben_project11/launch/ben_core_launch.py` (which `sim_robot_launch.py` includes), so the sim-side block produced two `/ben/sea_surface_estimator` processes racing each other and four spurious lifecycle-transition errors at startup.
- Remove three imports (`LifecycleNode`, `LifecycleTransition`, `lifecycle_msgs.msg.Transition`) that no longer have any users in the file.

Closes #58

## Test plan

- [x] `./simulation_ws/build.sh marine_simulation` — clean.
- [x] `ros2 launch marine_simulation simulator_launch.py` (45 s window):
  - Exactly one `sea_surface_estimator-N` process in the log (was 2 before).
  - Zero `Failed to make transition` / `Transition is not registered` / `No transition matching` errors (was 14 before).
  - `bt_task_navigator connected with bond` and full nav lifecycle activates as before.
- [ ] Reviewer: confirm `ben_core_launch.py:141-149` (`mru_transform/sea_surface_estimator_launch.py` include) is the intended single home for sim runs. The `sea_surface_frame` ends up as `ben/map_tide` either way.

## Notes

- Other platforms (`bizzyboat_project11/core_launch.py`, `seafloor_echoboat_project11/echo_launch.py`) each launch `sea_surface_estimator` exactly once via their own core launch — they were never affected.
- Possible follow-up (separate issue): the `mru_transform_node` + `sea_surface_estimator` + `chart_datum` triplet is copy-pasted across all three platform launches. Hoisting it into `marine_autonomy/launch/robot_core_launch.py` would deduplicate that pattern across platforms. Not in scope for this PR.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
