### PR TITLE
Record controller-internal topics for line-following diagnosis (#62)

### DIFF
--- a/marine_simulation/config/sim_bag_recording.yaml
+++ b/marine_simulation/config/sim_bag_recording.yaml
@@ -14,6 +14,7 @@
       - /ben/run_tasks/_action/send_goal
       # Nav2 actions
       - /ben/follow_path/_action/status
+      - /ben/follow_path/_action/feedback
       - /ben/compute_path_through_poses/_action/status
       - /ben/hover/_action/status
       # Planning and control
@@ -23,6 +24,18 @@
       - /ben/collision_monitor_state
       - /ben/local_costmap/published_footprint
       - /ben/piloting_mode/autonomous/cmd_vel
+      # Controller-internal (line-following diagnosis). pid_state carries the
+      # cross-track error + PID terms — the crab follower feeds cross_track_error
+      # into the PID, so this is the only published copy of cross-track (it is
+      # otherwise DEBUG-logged only). received_global_plan is the exact path the
+      # controller is tracking via setPlan.
+      - /ben/FollowPath/pid/pid_state
+      - /ben/received_global_plan
+      # Optional, heavier (full grids at update rate) — uncomment to debug whether
+      # the chart/obstacle layer is nudging the boat off the line:
+      # - /ben/local_costmap/costmap
+      # - /ben/local_costmap/costmap_updates
+      # - /ben/plan_smoothed
       # Position / velocity / state
       - /ben/odom
       - /ben/sensors/nav/position


### PR DESCRIPTION
Adds the controller-internal topics most diagnostic for line-following to the sim bag
recorder. Surfaced while troubleshooting line-following struggles in sim: a bag could
show the boat deviating from the line (odom vs. `/ben/plan`) but not *why* — cross-track
error was recorded nowhere (only `RCLCPP_DEBUG`-logged by `CrabbingPathFollower`; its sole
published copy is `pid_state`, which wasn't in the record list).

## Added (cheap, high-value)

- `/ben/FollowPath/pid/pid_state` — cross-track error + PID terms (the #1 line-following plot)
- `/ben/received_global_plan` — the exact path the controller tracks via `setPlan`
- `/ben/follow_path/_action/feedback` — per-cycle distance-to-goal / speed (only `_action/status` was recorded)

## Left commented (opt-in, heavier)

`local_costmap/costmap` (+ updates) and `plan_smoothed` — full grids at update rate are
costly; documented inline for when the chart/obstacle layer is the suspect.

Config-only change; topic names confirmed live against the running sim. YAML validated.

Closes #62.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
