### PR TITLE
sim: set detections_to_pointcloud TF frames + odom for the namespaced sim (closes #64)

### DIFF
--- a/marine_simulation/launch/sim_robot_launch.py
+++ b/marine_simulation/launch/sim_robot_launch.py
@@ -274,31 +274,44 @@ def generate_launch_description():
                     ]),
                     GroupAction(
                         actions=[
+                            # detections_to_pointcloud sources the error model's
+                            # pose from TF (roll/pitch from level_frame, heave
+                            # from tide_frame) + /odom for SOG, since
+                            # cube_bathymetry #31/#33 retired the old
+                            # NavigationSensors topic path. Its frame params
+                            # default to unprefixed names, so the namespaced sim
+                            # MUST set them or the attitude TF lookup misses ->
+                            # NaN uncertainty -> empty grid. mru_transform_node
+                            # broadcasts <ns>/base_link_north_up and (via
+                            # sea_surface_estimator) <ns>/map_tide.
                             SetParameter(
-                                name='sensors.default.topics.position',
+                                name='base_link_frame',
+                                value=PythonExpression(
+                                    expression=['"', namespace, '/base_link"']
+                                )
+                            ),
+                            SetParameter(
+                                name='level_frame',
                                 value=PythonExpression(
                                     expression=[
-                                        '"/', namespace,
-                                        '/sensors/nav/position"'
+                                        '"', namespace, '/base_link_north_up"'
                                     ]
                                 )
                             ),
                             SetParameter(
-                                name='sensors.default.topics.orientation',
+                                name='tide_frame',
                                 value=PythonExpression(
-                                    expression=[
-                                        '"/', namespace,
-                                        '/sensors/nav/orientation"'
-                                    ]
+                                    expression=['"', namespace, '/map_tide"']
                                 )
                             ),
-                            SetParameter(
-                                name='sensors.default.topics.velocity',
-                                value=PythonExpression(
-                                    expression=[
-                                        '"/', namespace,
-                                        '/sensors/nav/velocity"'
-                                    ]
+                            # Speed over ground for the error model. The mbes_sim
+                            # group's odom remap does not reach this group, and
+                            # under this namespace a bare `odom` would resolve to
+                            # <ns>/sensors/mbes/odom; point it at the real topic.
+                            SetRemap(
+                                src='odom',
+                                dst=PythonExpression(
+                                    expression=['"/', namespace, '/odom"']
                                 )
                             ),
                             IncludeLaunchDescription(


### PR DESCRIPTION
## What

Restores the simulator's sonar→grid path. The MBES sim produced detections and `detections_to_pointcloud` produced soundings, but no grid reached CAMP/rviz.

## Root cause

`cube_bathymetry` #31/#33 retired `detections_to_pointcloud`'s `NavigationSensors` pose path in favour of TF (roll/pitch from `level_frame`, heave from `tide_frame`) + `/odom` (SOG). Its frame params default to **unprefixed** names. This launch predates that and never set them — it still set the now-dead `sensors.default.topics.{position,orientation,velocity}` params. Under the sim namespace (`ben/`) the attitude TF lookup missed → NaN roll/pitch → NaN uncertainty → the CUBE grid dropped every cell → empty grid.

## Fix

In the `detections_to_pointcloud` group of `sim_robot_launch.py`:
- Replace the three dead `sensors.default.topics.*` params with `base_link_frame` / `level_frame` / `tide_frame`, namespaced to the robot. (`mru_transform_node` broadcasts `<ns>/base_link_north_up`; `sea_surface_estimator` broadcasts `<ns>/map_tide`.)
- Add an `odom` remap in this group — the mbes_sim group's odom remap does **not** reach here, and a bare `odom` resolves under `<ns>/sensors/mbes`; without it SOG is NaN → NaN uncertainty → empty grid.

`cube_bathymetry_node`'s `map_frame` is already set to `<ns>/map`.

## Verification

`generate_launch_description()` still constructs cleanly. The cube pipeline is proven to grid correctly given valid frames + odom (offline replay of the 2026-06-09 boat bag produced 40 GridMaps); this fix supplies both for the sim. Best confirmed by a live sim run (grid renders in CAMP/rviz).

Pairs with rolker/cube_bathymetry#38 (gridding hardening), which makes the node drop NaN soundings + warn instead of silently emptying the grid.

Closes #64.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
