### PR TITLE
Sim: BizzyBoat at Lake Massabesic (non-Gazebo)

### DIFF
--- a/.agent/work-plans/issue-66/plan.md
+++ b/.agent/work-plans/issue-66/plan.md
@@ -23,13 +23,24 @@ The `drix` flag is the existing alternate-platform precedent; the MBES + cube gr
 1. **Add a `platform` arg** (`ben` default, `bizzy`) to `sim_robot_launch.py` + pass-through from
    `simulator_launch.py` (which currently hardcodes `namespace='ben'` at its include). Drive the
    conditional swaps below off it, mirroring the `drix` pattern.
-2. **Autonomy bringup swap** — for `bizzy`, bring up BizzyBoat's Nav2 stack (model 240 +
-   `bizzyboat_project11/config/nav2_overlay.yaml`) with `use_sim_time` instead of
-   `ben_core_launch.py`. Exact mechanism = **Open Question 1**.
-3. **`asv_sim/config/bizzyboat.yaml`** — mirror `ben.yaml`: `platforms.bizzy.model`,
+2. **Autonomy bringup swap (anti-drift)** — for `bizzy`, include a **sim-aware BizzyBoat core
+   launch** that reuses the boat's REAL config (`nav2_overlay.yaml` + base) and layers a small new
+   `bizzyboat_sim.yaml` overlay only under `is_simulator` — mirroring `ben_core_launch.py:103-110`
+   (`ben.yaml` + `ben_sim.yaml`). The sim repo includes it with `is_simulator:=true`, exactly as it
+   includes `ben_core_launch.py` today. **No config duplication: sim and field read one source.**
+   Bizzy's current `core_launch.py` is hardware-coupled (real FCU `/dev/fcu` via mavros + sensor
+   drivers), so add a thin **`bizzyboat_sim_core_launch.py`** (in `bizzyboat_project11`) that brings
+   up only the sim-shareable stack (autonomy + nav2 + mru_transform + sea_surface_estimator),
+   reusing the same config files. (Cross-repo change — see Scope.) Cleaner long-term: split bizzy's
+   bringup into autonomy-vs-hardware like Ben's.
+3. **`asv_sim/config/bizzyboat.yaml`** — mirror `ben.yaml`: `platforms.bizzy.model: echoboat240`,
    `mru_frame: bizzy/motion_sensor`, `start_lat: 42.990559`, `start_lon: -71.392958`,
-   `start_heading: <353.6 or ENU-equiv>` (06-12 last pose). Confirm `start_heading` convention
-   against `asv_sim` (compass vs ENU-yaw) — **Open Question 2**.
+   `start_heading: 353.6` (06-12 last pose; **compass-true degrees** confirmed via `platform.py:227`
+   `yaw=90-heading` + `geodesic.py:24`).
+3b. **`asv_sim/config/echoboat240.yaml`** (new) — `models.echoboat240.*` mirroring `cw4.yaml` with
+   240 mass/length/speed + `propulsion_type: jet` (thrust proxy, per Roland). **Fidelity gap:** the
+   240 yaws by vectored thrust (rotates near zero speed); `cw4`'s flow-dependent rudder model won't.
+   Add a vectored-yaw term to `asv_sim/dynamics.py` so the model yaws at low/zero speed.
 4. **`platforms` + config selection** — replace hardcoded `['ben']` (`:180`) with the namespace;
    load `bizzyboat.yaml` (+ model config) under `IfCondition(platform==bizzy)`.
 5. **No current** — set `asv_sim` environment current to 0 for the bizzy path (verify param name
@@ -51,14 +62,25 @@ The `drix` flag is the existing alternate-platform precedent; the MBES + cube gr
 
 ## Files to Change
 
+**Repo `unh_marine_simulation`:**
+
 | File | Change |
 |------|--------|
-| `marine_simulation/launch/sim_robot_launch.py` | Add `platform` arg; conditional core-launch + config + `platforms` namespace; MBES `grid_file` SetParameter; zero current |
+| `marine_simulation/launch/sim_robot_launch.py` | Add `platform` arg; conditional core-launch (ben vs bizzy sim-core) + config + `platforms` namespace; MBES `grid_file` SetParameter; zero current |
 | `marine_simulation/launch/simulator_launch.py` | Add/forward `platform` (+ namespace) arg |
 | `marine_simulation/launch/bizzyboat_massabesic_launch.py` (new) | One-line BizzyBoat-Massabesic entry |
-| `asv_sim/config/bizzyboat.yaml` (new) | Platform model + 06-12 spawn pose, no current |
+| `asv_sim/config/bizzyboat.yaml` (new) | `echoboat240` model + 06-12 spawn pose (353.6° compass), no current |
+| `asv_sim/config/echoboat240.yaml` (new) | `models.echoboat240.*` — 240 dynamics, jet proxy |
+| `asv_sim/asv_sim/dynamics.py` | Vectored-yaw term so the model yaws at low/zero speed |
 | `<obstacle emulator>.py` (new) + launch | Seeded random obstacles → `<ns>/sea_surface/lethal_grid` within 25 m |
-| `*/setup.py` / `CMakeLists.txt` | Register new node/launch/config |
+| `*/setup.py` | Register new node/launch/config |
+
+**Repo `unh_echoboats_project11` (cross-repo):**
+
+| File | Change |
+|------|--------|
+| `bizzyboat_project11/launch/bizzyboat_sim_core_launch.py` (new) | Sim-shareable bringup (autonomy + nav2 + transforms), reuses real `bizzyboat.yaml`/`nav2_overlay.yaml`, layers `bizzyboat_sim.yaml` under `is_simulator` — mirrors `ben_core_launch.py` |
+| `bizzyboat_project11/config/bizzyboat_sim.yaml` (new) | Sim deltas only (nav from asv_sim, sim tide threshold) — mirrors `ben_sim.yaml`. **No copy of nav2_overlay.** |
 
 ## Principles Self-Check
 
@@ -85,17 +107,19 @@ The `drix` flag is the existing alternate-platform precedent; the MBES + cube gr
 
 ## Open Questions
 
-1. **Bizzy autonomy bringup in sim** — cleanest path to run BizzyBoat's Nav2 (model 240 +
-   `nav2_overlay.yaml`) under sim_time: (a) new sim-aware bringup *in the sim repo* pointing
-   `nav2_bringup` at bizzy's params (keeps changes one-repo, avoids real-hardware drivers), or
-   (b) add an `is_simulator` path to `bizzyboat_project11` (cross-repo). Lean (a) — the bug is
-   pure Nav2, no hardware needed. Confirm with Roland.
-2. **`start_heading` convention** in `asv_sim` (compass-true vs ENU-yaw) — set 353.6 or -6.5 accordingly.
-3. **Hydro model for bizzy** — reuse `cw4` for now (planner bug is model-independent) or add an
-   echoboat-240 model config? Proposed: reuse `cw4`, follow-up for a real model.
+1. **Bizzy autonomy bringup in sim** — RESOLVED (anti-drift): mirror Ben — a sim-aware bringup in
+   `bizzyboat_project11` reusing the boat's real config + a small `bizzyboat_sim.yaml` overlay; the
+   sim includes it with `is_simulator:=true`. Cross-repo, but the only no-duplication path. *Pending
+   Roland's final OK on the cross-repo change + the thin-sim-core (ii) vs full-split (i) choice.*
+2. **`start_heading` convention** — RESOLVED: compass-true degrees (`platform.py:227`,
+   `geodesic.py:24`); use 353.6.
+3. **Hydro model for bizzy** — RESOLVED: new `echoboat240` model (mimic real 240, jet as thrust
+   proxy), plus a vectored-yaw `dynamics.py` extension so it yaws at zero speed.
 
 ## Estimated Scope
 
-Two PRs on a stacked branch: **PR-A** scaffolding (platform arg + bizzy config + MBES grid +
-launch entry, Ben path unbroken); **PR-B** obstacle emulator + the reproduction write-up. Both
-target `jazzy`. The Phase-4 `bathymetry_geotiff_layer` fix is a separate issue/repo.
+Cross-repo, stacked: **PR-A** (`unh_echoboats_project11`) sim-aware bizzy core launch +
+`bizzyboat_sim.yaml`; **PR-B** (`unh_marine_simulation`) platform arg + `bizzyboat.yaml` +
+`echoboat240` model + `dynamics.py` vectored-yaw + MBES grid + launch entry (Ben path unbroken);
+**PR-C** (`unh_marine_simulation`) obstacle emulator + reproduction write-up. All target `jazzy`.
+The Phase-4 `bathymetry_geotiff_layer` fix is a separate issue/repo.

--- a/.agent/work-plans/issue-66/plan.md
+++ b/.agent/work-plans/issue-66/plan.md
@@ -38,9 +38,13 @@ The `drix` flag is the existing alternate-platform precedent; the MBES + cube gr
    `start_heading: 353.6` (06-12 last pose; **compass-true degrees** confirmed via `platform.py:227`
    `yaw=90-heading` + `geodesic.py:24`).
 3b. **`asv_sim/config/echoboat240.yaml`** (new) — `models.echoboat240.*` mirroring `cw4.yaml` with
-   240 mass/length/speed + `propulsion_type: jet` (thrust proxy, per Roland). **Fidelity gap:** the
-   240 yaws by vectored thrust (rotates near zero speed); `cw4`'s flow-dependent rudder model won't.
-   Add a vectored-yaw term to `asv_sim/dynamics.py` so the model yaws at low/zero speed.
+   240 mass/length/speed + `propulsion_type: jet`. **No `dynamics.py` change needed:** the jet
+   branch (`dynamics.py:229-254`) already vectors yaw — `yaw_thrust = thrust·sin(rudder)` with
+   `thrust ∝ rpm` (not hull speed), so it pivots at zero forward speed (requires throttle, like the
+   real vectored thrusters). Tune jet params to the empirical targets: `go_straight_coefficient`
+   (yaw damping) → ~0.9-1.0 rad/s cap; `mass`+`max_power` → 0.6 m/s² launch + 1.9 m/s top;
+   `drag_coefficient` → ~10 s coast-down. (The prop branch is flow-dependent and would NOT pivot —
+   jet is the correct proxy, confirming Roland's call.)
 4. **`platforms` + config selection** — replace hardcoded `['ben']` (`:180`) with the namespace;
    load `bizzyboat.yaml` (+ model config) under `IfCondition(platform==bizzy)`.
 5. **No current** — set `asv_sim` environment current to 0 for the bizzy path (verify param name
@@ -70,8 +74,7 @@ The `drix` flag is the existing alternate-platform precedent; the MBES + cube gr
 | `marine_simulation/launch/simulator_launch.py` | Add/forward `platform` (+ namespace) arg |
 | `marine_simulation/launch/bizzyboat_massabesic_launch.py` (new) | One-line BizzyBoat-Massabesic entry |
 | `asv_sim/config/bizzyboat.yaml` (new) | `echoboat240` model + 06-12 spawn pose (353.6° compass), no current |
-| `asv_sim/config/echoboat240.yaml` (new) | `models.echoboat240.*` — 240 dynamics, jet proxy |
-| `asv_sim/asv_sim/dynamics.py` | Vectored-yaw term so the model yaws at low/zero speed |
+| `asv_sim/config/echoboat240.yaml` (new) | `models.echoboat240.*` — 240 dynamics, `propulsion_type: jet` (jet branch already vectors yaw; tune to empirical targets) |
 | `<obstacle emulator>.py` (new) + launch | Seeded random obstacles → `<ns>/sea_surface/lethal_grid` within 25 m |
 | `*/setup.py` | Register new node/launch/config |
 
@@ -113,13 +116,35 @@ The `drix` flag is the existing alternate-platform precedent; the MBES + cube gr
    Roland's final OK on the cross-repo change + the thin-sim-core (ii) vs full-split (i) choice.*
 2. **`start_heading` convention** — RESOLVED: compass-true degrees (`platform.py:227`,
    `geodesic.py:24`); use 353.6.
-3. **Hydro model for bizzy** — RESOLVED: new `echoboat240` model (mimic real 240, jet as thrust
-   proxy), plus a vectored-yaw `dynamics.py` extension so it yaws at zero speed.
+3. **Hydro model for bizzy** — RESOLVED: new `echoboat240` model, `propulsion_type: jet`. The jet
+   branch already vectors yaw (pivots at zero speed) — **no `dynamics.py` extension needed**. Tune
+   jet params to empirical targets derived from Friday's odom + `bizzyboat_performance.md`.
+
+## echoboat240 model spec (empirical, for asv_sim)
+
+Derived from Friday's odom + the boat's current-corrected dynamics doc + datasheet
+(Roland: derive from bag + look up mass). Targets the asv_sim model params to reproduce:
+
+| Quantity | Value | Source |
+|---|---|---|
+| Hull L × W | 2.4 m × 0.9 m | manual §1.3 (`platform.yaml`) |
+| Hull mass | ~159 kg (no battery/payload; **operating mass higher** with M3/batteries/sensors — refine) | Seafloor datasheet |
+| Max forward speed | **1.9 m/s** STW (current-corrected) | `bizzyboat_performance.md` (Friday SOG max 2.14 incl. current) |
+| Cruise | 1.52 m/s | `bizzyboat_performance.md` |
+| Hard-launch accel | ~0.6 m/s² peak, τ≈2.5 s | `bizzyboat_performance.md` |
+| Coast-down decel | ~0.15 m/s², τ≈9–10 s (~10–15 m to stop) | `bizzyboat_performance.md` |
+| Yaw-rate cap / pivot | 1.0 rad/s cap; **~0.9 rad/s pivot at full throttle (vectored → yaw at v≈0)** | `bizzyboat_performance.md`; Friday odom peak 1.11 rad/s |
+
+Model build (`propulsion_type: jet` — the jet branch already vectors yaw, pivots at zero speed):
+set `max_speed≈1.9`, `mass≈` operating estimate, tune `max_power`/`drag_coefficient` to hit
+~0.6 m/s² launch + τ≈10 s coast, and `go_straight_coefficient` (yaw damping) so full-throttle
+full-steer settles at ~0.9-1.0 rad/s. Reproduces real 240 feel, not datasheet guesses. No
+`dynamics.py` change.
 
 ## Estimated Scope
 
 Cross-repo, stacked: **PR-A** (`unh_echoboats_project11`) sim-aware bizzy core launch +
 `bizzyboat_sim.yaml`; **PR-B** (`unh_marine_simulation`) platform arg + `bizzyboat.yaml` +
-`echoboat240` model + `dynamics.py` vectored-yaw + MBES grid + launch entry (Ben path unbroken);
+`echoboat240` model (jet, no dynamics.py change) + MBES grid + launch entry (Ben path unbroken);
 **PR-C** (`unh_marine_simulation`) obstacle emulator + reproduction write-up. All target `jazzy`.
 The Phase-4 `bathymetry_geotiff_layer` fix is a separate issue/repo.

--- a/.agent/work-plans/issue-66/plan.md
+++ b/.agent/work-plans/issue-66/plan.md
@@ -1,0 +1,101 @@
+# Plan: Sim — BizzyBoat at Lake Massabesic (non-Gazebo), reproduce local-costmap-only planning
+
+## Issue
+
+https://github.com/rolker/unh_marine_simulation/issues/66
+
+## Context
+
+The `simulator_launch.py` → `sim_robot_launch.py` stack (`asv_sim` dynamics + `mbes_sim`
+reading a bathy GeoTIFF + the boat autonomy/Nav2 stack; **no Gazebo**) is hardcoded to Ben
+(`sim_robot_launch.py:88-102` includes `ben_core_launch.py`; `:180` sets `platforms: ['ben']`;
+`:150-161` loads `cw4.yaml` + `ben.yaml`). We want a **BizzyBoat at Lake Massabesic** variant
+that mirrors the boat's *current* field setup so Friday's "planner won't plan beyond the local
+costmap" bug reproduces (hypothesis: at a chart-less lake the global costmap has no spatial data
+beyond the ~100 m segmentation bubble). Then an obstacle emulator feeds the real
+`SeaSurfaceRelayLayer` to recreate local-only perception.
+
+The `drix` flag is the existing alternate-platform precedent; the MBES + cube groups
+(`:218-357`) are already namespace-driven, so they work for `bizzy` unchanged.
+
+## Approach
+
+1. **Add a `platform` arg** (`ben` default, `bizzy`) to `sim_robot_launch.py` + pass-through from
+   `simulator_launch.py` (which currently hardcodes `namespace='ben'` at its include). Drive the
+   conditional swaps below off it, mirroring the `drix` pattern.
+2. **Autonomy bringup swap** — for `bizzy`, bring up BizzyBoat's Nav2 stack (model 240 +
+   `bizzyboat_project11/config/nav2_overlay.yaml`) with `use_sim_time` instead of
+   `ben_core_launch.py`. Exact mechanism = **Open Question 1**.
+3. **`asv_sim/config/bizzyboat.yaml`** — mirror `ben.yaml`: `platforms.bizzy.model`,
+   `mru_frame: bizzy/motion_sensor`, `start_lat: 42.990559`, `start_lon: -71.392958`,
+   `start_heading: <353.6 or ENU-equiv>` (06-12 last pose). Confirm `start_heading` convention
+   against `asv_sim` (compass vs ENU-yaw) — **Open Question 2**.
+4. **`platforms` + config selection** — replace hardcoded `['ben']` (`:180`) with the namespace;
+   load `bizzyboat.yaml` (+ model config) under `IfCondition(platform==bizzy)`.
+5. **No current** — set `asv_sim` environment current to 0 for the bizzy path (verify param name
+   in `asv_sim` environment config).
+6. **MBES ground truth** — `SetParameter('grid_file', <massabesic_contour.tiff>)` in the MBES
+   group (alongside the existing `sonar_frame_id`/`ping_interval` SetParameters at `:220-229`).
+   Use the contour GeoTIFF we already have; full-truth composite is a later swap (cube#43).
+7. **Obstacle emulator node** (`mbes_sim` or a new small `marine_simulation` node): scatter `N`
+   seeded random obstacles over a configurable lake bbox, track boat pose via TF
+   (`<ns>/map_tide`→`<ns>/base_link`), publish `nav_msgs/OccupancyGrid` on
+   `<ns>/sea_surface/lethal_grid` (frame `<ns>/map_tide`, lethal=100) containing **only**
+   obstacles within `reveal_radius` (default 25 m). Params: `seed`, `obstacle_count` (15),
+   `reveal_radius` (25.0), `bbox`. Feeds the real `SeaSurfaceRelayLayer` unchanged.
+8. **Bizzy launch entry** — `bizzyboat_massabesic_launch.py` (thin wrapper over
+   `simulator_launch`/`sim_robot_launch` with `platform:=bizzy`, obstacle emulator on) for one-line
+   invocation.
+9. **Reproduce** — command a goal beyond the local window; confirm the planner cannot route to it.
+   Document the observed behavior in progress.md as the baseline.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `marine_simulation/launch/sim_robot_launch.py` | Add `platform` arg; conditional core-launch + config + `platforms` namespace; MBES `grid_file` SetParameter; zero current |
+| `marine_simulation/launch/simulator_launch.py` | Add/forward `platform` (+ namespace) arg |
+| `marine_simulation/launch/bizzyboat_massabesic_launch.py` (new) | One-line BizzyBoat-Massabesic entry |
+| `asv_sim/config/bizzyboat.yaml` (new) | Platform model + 06-12 spawn pose, no current |
+| `<obstacle emulator>.py` (new) + launch | Seeded random obstacles → `<ns>/sea_surface/lethal_grid` within 25 m |
+| `*/setup.py` / `CMakeLists.txt` | Register new node/launch/config |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Robustness / do it right | Emulator is **seeded/deterministic** (reproducible runs); reuses the *real* relay layer so the data path matches the boat — not a parallel fake costmap path. |
+| Reproduce before fixing | This issue deliberately recreates the field bug as a baseline before the Phase-4 fix; no premature fix bundled in. |
+| Verify, don't assume | The root-cause is a *hypothesis* to confirm in sim, not asserted as fact. |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0002 (bathy store) | No | Bathy→costmap layer (the fix) is deferred; this issue is sim infra only. |
+| (sim repo has no local ADR set) | — | Follows workspace Quality Standard + existing `drix` launch convention. |
+
+## Consequences
+
+| If we change... | Also update... | Included? |
+|---|---|---|
+| `sim_robot_launch.py` platform branching | Ben path must stay default + unbroken | Yes (regression-check Ben launch) |
+| New asv_sim platform | needs a hydro model (reuse `cw4` initially) | Yes (OQ3) |
+| Obstacle emulator topic/frame | must match `SeaSurfaceRelayLayer` contract (`OccupancyGrid`, `<ns>/sea_surface/lethal_grid`) | Yes |
+
+## Open Questions
+
+1. **Bizzy autonomy bringup in sim** — cleanest path to run BizzyBoat's Nav2 (model 240 +
+   `nav2_overlay.yaml`) under sim_time: (a) new sim-aware bringup *in the sim repo* pointing
+   `nav2_bringup` at bizzy's params (keeps changes one-repo, avoids real-hardware drivers), or
+   (b) add an `is_simulator` path to `bizzyboat_project11` (cross-repo). Lean (a) — the bug is
+   pure Nav2, no hardware needed. Confirm with Roland.
+2. **`start_heading` convention** in `asv_sim` (compass-true vs ENU-yaw) — set 353.6 or -6.5 accordingly.
+3. **Hydro model for bizzy** — reuse `cw4` for now (planner bug is model-independent) or add an
+   echoboat-240 model config? Proposed: reuse `cw4`, follow-up for a real model.
+
+## Estimated Scope
+
+Two PRs on a stacked branch: **PR-A** scaffolding (platform arg + bizzy config + MBES grid +
+launch entry, Ben path unbroken); **PR-B** obstacle emulator + the reproduction write-up. Both
+target `jazzy`. The Phase-4 `bathymetry_geotiff_layer` fix is a separate issue/repo.

--- a/.agent/work-plans/issue-66/progress.md
+++ b/.agent/work-plans/issue-66/progress.md
@@ -17,3 +17,23 @@ issue: 66
 - [ ] Bizzy autonomy bringup in sim: (a) sim-repo-only nav2_bringup at bizzy params [lean], or (b) cross-repo is_simulator path in bizzyboat_project11
 - [ ] `asv_sim` `start_heading` convention (compass-true 353.6 vs ENU-yaw -6.5)
 - [ ] Hydro model for bizzy: reuse `cw4` now vs add echoboat-240 model
+
+## Local Review
+**Status**: complete
+**When**: 2026-06-13 14:05 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: approved (after fixes)
+
+**PR**: #67 at `5c9c48a`
+**Mode**: post-PR
+**Depth**: Standard (reason: shared launch wiring + new model/config)
+**Must-fix**: 2 | **Suggestions**: 1
+
+### Findings
+- [x] (must-fix) `{'platforms': [namespace]}` collapses to a scalar string → asv_sim STRING_ARRAY crash for ALL platforms incl. ben regression; fixed via OpaqueFunction resolving namespace to a plain string — `marine_simulation/launch/sim_robot_launch.py`
+- [x] (must-fix) echoboat240 `clutch_engagement_rpm: 0.0` fed idle thrust → ~1.2 m/s uncommanded creep; engage above idle (800) — `asv_sim/config/echoboat240.yaml`
+- [x] (doc) default MBES grid is Portsmouth (~100 km away) → zero ground truth at Massabesic; clarified — `marine_simulation/launch/bizzyboat_massabesic_launch.py`
+- [ ] (suggestion, follow-up) `mbes_sim/bathy_grid.py` out-of-bounds guard relies on IndexError; negative indices silently wrap → fabricated depth. Pre-existing in mbes_sim (not this diff); harden with explicit bounds check.
+
+### Cross-pass note
+Lens A and Lens B disagreed on the platforms-param finding; resolved by empirical test (launch_ros `normalize_parameters`) — Lens A correct.

--- a/.agent/work-plans/issue-66/progress.md
+++ b/.agent/work-plans/issue-66/progress.md
@@ -1,0 +1,19 @@
+---
+issue: 66
+---
+
+# Issue #66 — Sim: BizzyBoat at Lake Massabesic (non-Gazebo) — reproduce local-costmap-only planning
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-13 11:40 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Plan**: `.agent/work-plans/issue-66/plan.md` at `92e9e68`
+**PR**: https://github.com/rolker/unh_marine_simulation/pull/67 (`[PLAN]` prefix)
+**Phases**: 2 (PR-A scaffolding; PR-B obstacle emulator + reproduction write-up)
+
+### Open questions
+- [ ] Bizzy autonomy bringup in sim: (a) sim-repo-only nav2_bringup at bizzy params [lean], or (b) cross-repo is_simulator path in bizzyboat_project11
+- [ ] `asv_sim` `start_heading` convention (compass-true 353.6 vs ENU-yaw -6.5)
+- [ ] Hydro model for bizzy: reuse `cw4` now vs add echoboat-240 model

--- a/asv_sim/config/bizzyboat.yaml
+++ b/asv_sim/config/bizzyboat.yaml
@@ -1,0 +1,18 @@
+asv_sim:
+  ros__parameters:
+    platforms.bizzy.model: echoboat240
+    # BizzyBoat reports nav in base_link (mavros child_frame_id; no separate
+    # motion_sensor frame in the URDF), so the sim nav is stamped there too.
+    platforms.bizzy.mru_frame: bizzy/base_link
+
+    # Lake Massabesic — last recorded pose from the 2026-06-12 deployment
+    # (mavros/global_position/global + SBG gps_hdt true heading, end of bag).
+    # start_heading is compass-true degrees (platform.py: yaw = 90 - heading).
+    platforms.bizzy.start_lat: 42.99055860
+    platforms.bizzy.start_lon: -71.39295800
+    platforms.bizzy.start_heading: 353.6
+
+    # No current in the sim (Roland) — these are global asv_sim environment
+    # params (not per-platform); loading this file zeroes the current.
+    environment.current.speed: 0.0
+    environment.current.noise.speed: 0.0

--- a/asv_sim/config/echoboat240.yaml
+++ b/asv_sim/config/echoboat240.yaml
@@ -1,0 +1,58 @@
+# Model for BizzyBoat — a Seafloor Systems EchoBoat-240 survey ASV.
+#
+# Parameters are tuned to reproduce the 240's measured behavior, not datasheet
+# guesses. Sources:
+#   - bizzyboat_performance.md (current-corrected, pooled across deployments)
+#   - 2026-06-12 deployment odom (/bizzy/odom)
+#   - Seafloor datasheet (hull dims + bare-hull mass)
+#
+# propulsion_type: jet — the asv_sim jet branch (dynamics.py) computes yaw from
+# thrust*sin(steer) with thrust driven by rpm (not hull speed), so the model
+# PIVOTS AT ZERO FORWARD SPEED. That faithfully proxies the 240's vectored
+# thrusters (which can rotate in place under throttle); the prop branch is
+# flow-dependent and would not pivot.
+#
+# How the high-level knobs map to behavior (asv_sim/model.py update_coefficients):
+#   max_force            = max_power / max_speed
+#   drag_coefficient     = max_force / max_speed^3      (thrust == drag at top speed)
+#   launch accel (v~=0)  ~= max_force / mass            -> tuned to ~0.6 m/s^2
+#   go_straight_coefficient = max_force*sin(max_rudder_angle) / max_turn_rate
+#       -> full-throttle + full-steer settles at max_turn_rate
+#
+# KNOWN MODEL LIMITATION: drag_coefficient is bound to max_force/max_speed^3, so
+# matching top speed (1.9) AND launch accel (0.6) fixes the cubic drag curve and
+# yields a coast-down (~0.3 m/s^2 at cruise) somewhat faster than the measured
+# ~0.15 m/s^2. Top speed, turn rate, and launch are matched (the behaviors that
+# matter for the nav/planner sim); coast-down is approximate.
+
+asv_sim:
+  ros__parameters:
+    # --- Propulsion (vectored-thrust proxy) ---
+    models.echoboat240.propulsion_type:     jet
+    models.echoboat240.max_rpm:             3200.0   # abstract engine speed (full throttle)
+    models.echoboat240.idle_rpm:            750.0
+    models.echoboat240.clutch_engagement_rpm: 0.0    # always engaged (electric)
+    models.echoboat240.gearbox_ratio:       1.0
+    models.echoboat240.max_rpm_change_rate: 1000.0   # ~2.5 s spin-up (hard-launch tau)
+    models.echoboat240.bucket_efficiency:   0.2      # reverse thrust fraction (~1.4 m/s rev)
+    models.echoboat240.bucket_change_rate:  0.5
+
+    # --- Speed / force tuning ---
+    # max_power is a MODEL abstraction (max_force = max_power/max_speed), not the
+    # real electrical power. 217 W -> max_force ~114 N -> ~0.6 m/s^2 launch at
+    # mass 190 kg, and equilibrium top speed 1.9 m/s.
+    models.echoboat240.max_speed:           1.9      # m/s STW, current-corrected
+    models.echoboat240.max_power:           217.0
+    models.echoboat240.mass:                190.0    # ~159 kg bare hull + M3/batteries/sensors (operating estimate)
+
+    # --- Steering / yaw (vectored) ---
+    models.echoboat240.max_rudder_angle:    33.0     # full steering deflection (deg)
+    models.echoboat240.max_rudder_change_rate: 60.0  # steering slews quickly (vectored, not a rudder)
+    models.echoboat240.max_turn_rate:       57.0     # deg/s ~= 1.0 rad/s (helm yaw cap; ~0.9 rad/s pivot observed)
+    models.echoboat240.rudder_distance:     1.0      # CoG -> thruster, m (2.4 m hull)
+    models.echoboat240.rudder_coefficient:  0.25     # prop-branch only (unused for jet)
+
+    # --- Disturbance noise (defaults) ---
+    models.echoboat240.thrust_noise:        0.1
+    models.echoboat240.yaw_rate_noise:      0.1
+    models.echoboat240.drag_noise:          0.1

--- a/asv_sim/config/echoboat240.yaml
+++ b/asv_sim/config/echoboat240.yaml
@@ -31,7 +31,10 @@ asv_sim:
     models.echoboat240.propulsion_type:     jet
     models.echoboat240.max_rpm:             3200.0   # abstract engine speed (full throttle)
     models.echoboat240.idle_rpm:            750.0
-    models.echoboat240.clutch_engagement_rpm: 0.0    # always engaged (electric)
+    # Engage above idle so a zero-throttle boat produces NO thrust and holds
+    # station (electric thrusters idle to zero). With engagement <= idle the
+    # jet model feeds idle_rpm thrust and the boat creeps ~1.2 m/s uncommanded.
+    models.echoboat240.clutch_engagement_rpm: 800.0
     models.echoboat240.gearbox_ratio:       1.0
     models.echoboat240.max_rpm_change_rate: 1000.0   # ~2.5 s spin-up (hard-launch tau)
     models.echoboat240.bucket_efficiency:   0.2      # reverse thrust fraction (~1.4 m/s rev)

--- a/marine_simulation/launch/bizzyboat_massabesic_launch.py
+++ b/marine_simulation/launch/bizzyboat_massabesic_launch.py
@@ -1,0 +1,54 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+from launch.substitutions import PathJoinSubstitution
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+    """BizzyBoat (EchoBoat 240) simulated at Lake Massabesic (non-Gazebo).
+
+    One-line entry: wraps sim_robot_launch.py with platform:=bizzy. Brings up
+    the boat's real autonomy + nav2 stack (via bizzyboat_sim_core_launch.py,
+    reusing the field nav2_overlay.yaml), the echoboat240 asv_sim dynamics model
+    spawned at the 2026-06-12 last-recorded pose with no current, and the
+    simulated MBES sampling the Massabesic ground-truth grid. The boat's costmap
+    starts from only its field config (currently chart_layer disabled, local
+    costmap 0.5 m / 350 m — the 2026-06-12 field changes), so this reproduces the
+    "planner won't plan beyond the local costmap" setup.
+
+    The operator/RViz station and bag recording (simulator_launch.py extras) are
+    not included here yet — run them separately or add as a follow-up.
+    """
+    mbes_grid_file = LaunchConfiguration('mbes_grid_file')
+    mbes_grid_file_arg = DeclareLaunchArgument(
+        'mbes_grid_file',
+        default_value=PathJoinSubstitution([
+            FindPackageShare('mbes_sim'), 'data', 'US5NH02M.tiff'
+        ]),
+        description='Massabesic ground-truth bathymetry GeoTIFF for the '
+        'simulated MBES. Defaults to the packaged sample until a single '
+        'Massabesic bathymetry grid is built (follow-up).'
+    )
+
+    return LaunchDescription([
+        mbes_grid_file_arg,
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(
+                PathJoinSubstitution([
+                    FindPackageShare('marine_simulation'),
+                    'launch',
+                    'sim_robot_launch.py'
+                ])
+            ),
+            launch_arguments={
+                'platform': 'bizzy',
+                'namespace': 'bizzy',
+                'sim_name': 'bizzy',
+                'enable_bridge': 'false',
+                'mbes_grid_file': mbes_grid_file,
+            }.items()
+        ),
+    ])

--- a/marine_simulation/launch/bizzyboat_massabesic_launch.py
+++ b/marine_simulation/launch/bizzyboat_massabesic_launch.py
@@ -8,7 +8,7 @@ from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
-    """BizzyBoat (EchoBoat 240) simulated at Lake Massabesic (non-Gazebo).
+    """Launch the BizzyBoat (EchoBoat 240) sim at Lake Massabesic (non-Gazebo).
 
     One-line entry: wraps sim_robot_launch.py with platform:=bizzy. Brings up
     the boat's real autonomy + nav2 stack (via bizzyboat_sim_core_launch.py,
@@ -29,8 +29,10 @@ def generate_launch_description():
             FindPackageShare('mbes_sim'), 'data', 'US5NH02M.tiff'
         ]),
         description='Massabesic ground-truth bathymetry GeoTIFF for the '
-        'simulated MBES. Defaults to the packaged sample until a single '
-        'Massabesic bathymetry grid is built (follow-up).'
+        'simulated MBES. NOTE: the default packaged sample is a Portsmouth NH '
+        'grid (~100 km away), so the MBES produces NO depth/detections at the '
+        'Massabesic spawn until a real Massabesic bathymetry grid is built and '
+        'passed here (follow-up).'
     )
 
     return LaunchDescription([

--- a/marine_simulation/launch/sim_robot_launch.py
+++ b/marine_simulation/launch/sim_robot_launch.py
@@ -53,11 +53,33 @@ def generate_launch_description():
     enable_bridge = LaunchConfiguration('enable_bridge')
     use_sim_time = LaunchConfiguration('use_sim_time')
     drix = LaunchConfiguration('drix')
+    platform = LaunchConfiguration('platform')
     no_sim = LaunchConfiguration('no_sim')
     tide_speed_factor = LaunchConfiguration('tide_speed_factor')
+    mbes_grid_file = LaunchConfiguration('mbes_grid_file')
+
+    # Platform selector. 'ben' (default) brings up ben_core_launch + the cw4
+    # model; 'bizzy' brings up bizzyboat_sim_core_launch + the echoboat240
+    # model (BizzyBoat at Lake Massabesic). The legacy `drix` flag is preserved
+    # for the (currently commented) DRIX path, so is_ben also gates on it.
+    is_ben = IfCondition(PythonExpression(
+        ["'", platform, "' == 'ben' and '", drix, "' == 'false'"]))
+    is_bizzy = IfCondition(PythonExpression(["'", platform, "' == 'bizzy'"]))
 
     namespace_arg = DeclareLaunchArgument(
         'namespace', default_value=TextSubstitution(text='ben')
+    )
+    platform_arg = DeclareLaunchArgument(
+        'platform', default_value=TextSubstitution(text='ben'),
+        description="Simulated platform: 'ben' or 'bizzy'."
+    )
+    mbes_grid_file_arg = DeclareLaunchArgument(
+        'mbes_grid_file',
+        default_value=PathJoinSubstitution([
+            FindPackageShare('mbes_sim'), 'data', 'US5NH02M.tiff'
+        ]),
+        description='Ground-truth bathymetry GeoTIFF for the simulated MBES. '
+        'For BizzyBoat-Massabesic, point this at the Massabesic bathymetry grid.'
     )
     sim_name_arg = DeclareLaunchArgument(
         'sim_name', default_value=namespace
@@ -93,10 +115,28 @@ def generate_launch_description():
                 'ben_core_launch.py'
             ])
         ),
-        condition=UnlessCondition(drix),
+        condition=is_ben,
         launch_arguments={
             'namespace': namespace,
             'enable_bridge': enable_bridge,
+            'is_simulator': 'true',
+        }.items()
+    )
+
+    # BizzyBoat (EchoBoat 240) sim-aware core bringup. Reuses the boat's real
+    # config (nav2_overlay.yaml + base) and layers bizzyboat_sim.yaml under
+    # is_simulator — no config duplication. Mirrors the ben_core include above.
+    launch_bizzy_core_include = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution([
+                FindPackageShare('bizzyboat_project11'),
+                'launch',
+                'bizzyboat_sim_core_launch.py'
+            ])
+        ),
+        condition=is_bizzy,
+        launch_arguments={
+            'namespace': namespace,
             'is_simulator': 'true',
         }.items()
     )
@@ -151,13 +191,27 @@ def generate_launch_description():
                 PathJoinSubstitution([
                     FindPackageShare('asv_sim'), 'config', 'cw4.yaml'
                 ]),
-                condition=UnlessCondition(drix)
+                condition=is_ben
             ),
             SetParametersFromFile(
                 PathJoinSubstitution([
                     FindPackageShare('asv_sim'), 'config', 'ben.yaml'
                 ]),
-                condition=UnlessCondition(drix)
+                condition=is_ben
+            ),
+            # BizzyBoat (EchoBoat 240): the echoboat240 hydro model + the
+            # platform spawn (Massabesic pose, no current).
+            SetParametersFromFile(
+                PathJoinSubstitution([
+                    FindPackageShare('asv_sim'), 'config', 'echoboat240.yaml'
+                ]),
+                condition=is_bizzy
+            ),
+            SetParametersFromFile(
+                PathJoinSubstitution([
+                    FindPackageShare('asv_sim'), 'config', 'bizzyboat.yaml'
+                ]),
+                condition=is_bizzy
             ),
             SetParametersFromFile(
                 PathJoinSubstitution([
@@ -177,7 +231,7 @@ def generate_launch_description():
                 name='asv_sim',
                 emulate_tty=True,
                 parameters=[
-                    {'platforms': ['ben']},
+                    {'platforms': [namespace]},
                     {'environment.tide.speed_factor': PythonExpression(
                         expression=['float(', tide_speed_factor, ')']
                     )},
@@ -226,6 +280,13 @@ def generate_launch_description():
                     SetParameter(
                         name='ping_interval',
                         value=0.2
+                    ),
+                    # Ground-truth bathymetry the simulated MBES samples. For
+                    # BizzyBoat-Massabesic this is the Massabesic grid; the boat's
+                    # costmap starts from only the contour prior (set elsewhere).
+                    SetParameter(
+                        name='grid_file',
+                        value=mbes_grid_file
                     ),
                     SetRemap(
                         src='detections',
@@ -385,10 +446,13 @@ def generate_launch_description():
         enable_bridge_arg,
         use_sim_time_arg,
         drix_arg,
+        platform_arg,
         no_sim_arg,
         tide_speed_factor_arg,
+        mbes_grid_file_arg,
         set_use_sim_time,
         launch_ben_core_include,
+        launch_bizzy_core_include,
         # launch_drix_core_include,
         asv_helm_group,
         sim_group,

--- a/marine_simulation/launch/sim_robot_launch.py
+++ b/marine_simulation/launch/sim_robot_launch.py
@@ -32,6 +32,7 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.actions import GroupAction
 from launch.actions import IncludeLaunchDescription
+from launch.actions import OpaqueFunction
 from launch.conditions import IfCondition
 from launch.conditions import UnlessCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
@@ -185,6 +186,34 @@ def generate_launch_description():
         ],
     )
 
+    def make_asv_sim_node(context, *args, **kwargs):
+        # Resolve the namespace to a plain string. asv_sim's `platforms` param
+        # is a STRING_ARRAY, but a single-element list holding a
+        # LaunchConfiguration substitution normalizes to a scalar string
+        # (launch_ros collapses substitution-lists), which fails the node's
+        # type check and crashes it on startup. Resolving here keeps a real
+        # one-element list and fully resolves the remappings.
+        ns = LaunchConfiguration('namespace').perform(context)
+        return [Node(
+            package='asv_sim',
+            executable='asv_sim',
+            name='asv_sim',
+            emulate_tty=True,
+            parameters=[
+                {'platforms': [ns]},
+                {'environment.tide.speed_factor': PythonExpression(
+                    expression=['float(', tide_speed_factor, ')']
+                )},
+            ],
+            remappings=[
+                (ns + '/position', ns + '/sensors/nav/position'),
+                (ns + '/orientation', ns + '/sensors/nav/orientation'),
+                (ns + '/velocity', ns + '/sensors/nav/velocity'),
+                (ns + '/throttle', ns + '/control/throttle'),
+                (ns + '/rudder', ns + '/control/rudder'),
+            ],
+        )]
+
     sim_group = GroupAction(
         actions=[
             SetParametersFromFile(
@@ -225,50 +254,7 @@ def generate_launch_description():
                 ]),
                 condition=IfCondition(drix)
             ),
-            Node(
-                package='asv_sim',
-                executable='asv_sim',
-                name='asv_sim',
-                emulate_tty=True,
-                parameters=[
-                    {'platforms': [namespace]},
-                    {'environment.tide.speed_factor': PythonExpression(
-                        expression=['float(', tide_speed_factor, ')']
-                    )},
-                ],
-                remappings=[
-                    (
-                        PathJoinSubstitution([namespace, 'position']),
-                        PathJoinSubstitution([
-                            namespace, 'sensors', 'nav', 'position'
-                        ])
-                    ),
-                    (
-                        PathJoinSubstitution([namespace, 'orientation']),
-                        PathJoinSubstitution([
-                            namespace, 'sensors', 'nav', 'orientation'
-                        ])
-                    ),
-                    (
-                        PathJoinSubstitution([namespace, 'velocity']),
-                        PathJoinSubstitution([
-                            namespace, 'sensors', 'nav', 'velocity'
-                        ])
-                    ),
-                    (
-                        PathJoinSubstitution([namespace, 'throttle']),
-                        PathJoinSubstitution([
-                            namespace, 'control', 'throttle'
-                        ])
-                    ),
-                    (
-                        PathJoinSubstitution([namespace, 'rudder']),
-                        PathJoinSubstitution([
-                            namespace, 'control', 'rudder'
-                        ])
-                    )
-                ]
-            ),
+            OpaqueFunction(function=make_asv_sim_node),
             GroupAction(
                 actions=[
                     SetParameter(


### PR DESCRIPTION
Closes #66

# Plan: Sim — BizzyBoat at Lake Massabesic (non-Gazebo), reproduce local-costmap-only planning

## Issue

https://github.com/rolker/unh_marine_simulation/issues/66

## Context

The `simulator_launch.py` → `sim_robot_launch.py` stack (`asv_sim` dynamics + `mbes_sim`
reading a bathy GeoTIFF + the boat autonomy/Nav2 stack; **no Gazebo**) is hardcoded to Ben
(`sim_robot_launch.py:88-102` includes `ben_core_launch.py`; `:180` sets `platforms: ['ben']`;
`:150-161` loads `cw4.yaml` + `ben.yaml`). We want a **BizzyBoat at Lake Massabesic** variant
that mirrors the boat's *current* field setup so Friday's "planner won't plan beyond the local
costmap" bug reproduces (hypothesis: at a chart-less lake the global costmap has no spatial data
beyond the ~100 m segmentation bubble). Then an obstacle emulator feeds the real
`SeaSurfaceRelayLayer` to recreate local-only perception.

The `drix` flag is the existing alternate-platform precedent; the MBES + cube groups
(`:218-357`) are already namespace-driven, so they work for `bizzy` unchanged.

## Approach

1. **Add a `platform` arg** (`ben` default, `bizzy`) to `sim_robot_launch.py` + pass-through from
   `simulator_launch.py` (which currently hardcodes `namespace='ben'` at its include). Drive the
   conditional swaps below off it, mirroring the `drix` pattern.
2. **Autonomy bringup swap** — for `bizzy`, bring up BizzyBoat's Nav2 stack (model 240 +
   `bizzyboat_project11/config/nav2_overlay.yaml`) with `use_sim_time` instead of
   `ben_core_launch.py`. Exact mechanism = **Open Question 1**.
3. **`asv_sim/config/bizzyboat.yaml`** — mirror `ben.yaml`: `platforms.bizzy.model`,
   `mru_frame: bizzy/motion_sensor`, `start_lat: 42.990559`, `start_lon: -71.392958`,
   `start_heading: <353.6 or ENU-equiv>` (06-12 last pose). Confirm `start_heading` convention
   against `asv_sim` (compass vs ENU-yaw) — **Open Question 2**.
4. **`platforms` + config selection** — replace hardcoded `['ben']` (`:180`) with the namespace;
   load `bizzyboat.yaml` (+ model config) under `IfCondition(platform==bizzy)`.
5. **No current** — set `asv_sim` environment current to 0 for the bizzy path (verify param name
   in `asv_sim` environment config).
6. **MBES ground truth** — `SetParameter('grid_file', <massabesic_contour.tiff>)` in the MBES
   group (alongside the existing `sonar_frame_id`/`ping_interval` SetParameters at `:220-229`).
   Use the contour GeoTIFF we already have; full-truth composite is a later swap (cube#43).
7. **Obstacle emulator node** (`mbes_sim` or a new small `marine_simulation` node): scatter `N`
   seeded random obstacles over a configurable lake bbox, track boat pose via TF
   (`<ns>/map_tide`→`<ns>/base_link`), publish `nav_msgs/OccupancyGrid` on
   `<ns>/sea_surface/lethal_grid` (frame `<ns>/map_tide`, lethal=100) containing **only**
   obstacles within `reveal_radius` (default 25 m). Params: `seed`, `obstacle_count` (15),
   `reveal_radius` (25.0), `bbox`. Feeds the real `SeaSurfaceRelayLayer` unchanged.
8. **Bizzy launch entry** — `bizzyboat_massabesic_launch.py` (thin wrapper over
   `simulator_launch`/`sim_robot_launch` with `platform:=bizzy`, obstacle emulator on) for one-line
   invocation.
9. **Reproduce** — command a goal beyond the local window; confirm the planner cannot route to it.
   Document the observed behavior in progress.md as the baseline.

## Files to Change

| File | Change |
|------|--------|
| `marine_simulation/launch/sim_robot_launch.py` | Add `platform` arg; conditional core-launch + config + `platforms` namespace; MBES `grid_file` SetParameter; zero current |
| `marine_simulation/launch/simulator_launch.py` | Add/forward `platform` (+ namespace) arg |
| `marine_simulation/launch/bizzyboat_massabesic_launch.py` (new) | One-line BizzyBoat-Massabesic entry |
| `asv_sim/config/bizzyboat.yaml` (new) | Platform model + 06-12 spawn pose, no current |
| `<obstacle emulator>.py` (new) + launch | Seeded random obstacles → `<ns>/sea_surface/lethal_grid` within 25 m |
| `*/setup.py` / `CMakeLists.txt` | Register new node/launch/config |

## Principles Self-Check

| Principle | Consideration |
|---|---|
| Robustness / do it right | Emulator is **seeded/deterministic** (reproducible runs); reuses the *real* relay layer so the data path matches the boat — not a parallel fake costmap path. |
| Reproduce before fixing | This issue deliberately recreates the field bug as a baseline before the Phase-4 fix; no premature fix bundled in. |
| Verify, don't assume | The root-cause is a *hypothesis* to confirm in sim, not asserted as fact. |

## ADR Compliance

| ADR | Triggered | How addressed |
|---|---|---|
| ADR-0002 (bathy store) | No | Bathy→costmap layer (the fix) is deferred; this issue is sim infra only. |
| (sim repo has no local ADR set) | — | Follows workspace Quality Standard + existing `drix` launch convention. |

## Consequences

| If we change... | Also update... | Included? |
|---|---|---|
| `sim_robot_launch.py` platform branching | Ben path must stay default + unbroken | Yes (regression-check Ben launch) |
| New asv_sim platform | needs a hydro model (reuse `cw4` initially) | Yes (OQ3) |
| Obstacle emulator topic/frame | must match `SeaSurfaceRelayLayer` contract (`OccupancyGrid`, `<ns>/sea_surface/lethal_grid`) | Yes |

## Open Questions

1. **Bizzy autonomy bringup in sim** — cleanest path to run BizzyBoat's Nav2 (model 240 +
   `nav2_overlay.yaml`) under sim_time: (a) new sim-aware bringup *in the sim repo* pointing
   `nav2_bringup` at bizzy's params (keeps changes one-repo, avoids real-hardware drivers), or
   (b) add an `is_simulator` path to `bizzyboat_project11` (cross-repo). Lean (a) — the bug is
   pure Nav2, no hardware needed. Confirm with Roland.
2. **`start_heading` convention** in `asv_sim` (compass-true vs ENU-yaw) — set 353.6 or -6.5 accordingly.
3. **Hydro model for bizzy** — reuse `cw4` for now (planner bug is model-independent) or add an
   echoboat-240 model config? Proposed: reuse `cw4`, follow-up for a real model.

## Estimated Scope

Two PRs on a stacked branch: **PR-A** scaffolding (platform arg + bizzy config + MBES grid +
launch entry, Ben path unbroken); **PR-B** obstacle emulator + the reproduction write-up. Both
target `jazzy`. The Phase-4 `bathymetry_geotiff_layer` fix is a separate issue/repo.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
