### PR TITLE
Sim: wire operator station (command_bridge_sender + CAMP) into bizzyboat_massabesic_launch

### DIFF
--- a/.agent/work-plans/issue-69/plan.md
+++ b/.agent/work-plans/issue-69/plan.md
@@ -59,14 +59,14 @@ already generic (parameterized by `robot_namespace`) and brings up
 
 ## Open Questions
 
-1. **Resolved (direction, per Roland):** pass `background_chart=''` (no chart). If
-   CAMP (`camp/CCOMAutonomousMissionPlanner`, which receives it as a positional
-   argv from `operator_ui_launch`) does NOT tolerate an empty background chart,
-   **fix the empty-tolerance in CAMP** rather than supplying a chart — the new
-   CAMP map code is removing background charts wholesale, so "no background chart"
-   is the correct long-term behavior. That fix would be a small cross-repo change
-   in `rolker/camp` (the original `camp/`, not the `camp2/` test framework). Tested
-   at implementation run; if a CAMP fix is needed it can be a sibling PR.
+1. **Resolved + confirmed needed.** Pass `background_chart=''` (no chart). CAMP's
+   arg loop (`camp/src/camp/main.cpp:27-38`) has **no empty guard**: the workspace
+   dir → `setWorkspace`, but an empty background arg falls to `else` →
+   `openBackground('')` (loads an empty chart). So the **CAMP empty-tolerance fix
+   IS required** — a one-line skip-empty-args guard in `main.cpp` — done as a
+   **sibling PR on `rolker/camp`** (the correct, long-term behavior since the new
+   map code drops background charts wholesale). This sim PR's CAMP-via-empty-chart
+   only works cleanly once that lands.
 
 ## Estimated Scope
 

--- a/.agent/work-plans/issue-69/plan.md
+++ b/.agent/work-plans/issue-69/plan.md
@@ -1,0 +1,68 @@
+# Plan: Wire operator station (command_bridge_sender + CAMP) into bizzyboat_massabesic_launch
+
+## Issue
+
+https://github.com/rolker/unh_marine_simulation/issues/69
+
+## Context
+
+`bizzyboat_massabesic_launch.py` brings up the boat (autonomy + nav2 + asv_sim +
+mbes) but not the operator side. The boat-side command chain runs
+(`command_bridge_receiver`, `helm_manager`), but the **operator-side
+`command_bridge_sender` is missing**, so CAMP's `send_command` is never converted
+to `command` → the boat won't change piloting mode. `simulator_launch.py`
+(`:95-123`) solves this for Ben by including `sim_operator_launch.py`, which is
+already generic (parameterized by `robot_namespace`) and brings up
+`operator_core_launch` (the sender, in the robot ns) + `operator_ui_launch` (CAMP).
+
+## Approach
+
+1. **Add a `sim_operator_launch` include** to `bizzyboat_massabesic_launch.py`,
+   mirroring `simulator_launch.py:103-123` but for `bizzy`, with no chart / no RViz:
+   - `robot_namespace='bizzy'`, `operator_namespace='operator'`, `enable_bridge='false'`,
+     `background_chart=''`, `rviz='false'`.
+   - Plain `IncludeLaunchDescription` (no `GroupAction`/`ROS_DOMAIN_ID` env — that
+     block in `simulator_launch` only applies when `enable_bridge` is true).
+2. **Update the docstring** — drop the "operator station … not included here yet"
+   note; state that it now brings up the operator station (CAMP + command sender)
+   on one ROS graph, so CAMP should not also be run separately.
+3. **Verify** `--show-args` loads (operator includes resolve) and the Ben path
+   (`simulator_launch`) is untouched.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `marine_simulation/launch/bizzyboat_massabesic_launch.py` | Add `sim_operator_launch` include for `bizzy` (no chart, no RViz); update docstring |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Reuse over duplication | Reuses the existing generic `sim_operator_launch.py`; no new config or forked operator launch. |
+| Mirror surrounding code | Follows `simulator_launch.py`'s operator-include pattern exactly (the established convention). |
+| Do it right / complete | Closes the full command path end-to-end; acceptance includes an actual CAMP→mode-switch test. |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| (none) | No | Sim launch wiring; no ADR-governed area (store/datum/etc.) touched. |
+
+## Consequences
+
+| If we change... | Also update... | Included? |
+|---|---|---|
+| Sim now launches CAMP | Operator should stop running CAMP separately (avoid two instances) | Yes — documented in docstring |
+| `background_chart=''` passed to operator_ui/CAMP | Confirm CAMP tolerates an empty chart (else adjust) | Open Question 1 |
+| Ben path | Must stay unaffected (only the bizzy entry changes) | Yes (separate file) |
+
+## Open Questions
+
+1. Does `operator_ui_launch` / CAMP tolerate `background_chart=''` (no chart)?
+   If it errors on empty, fall back (omit the arg to use CAMP's own default, or
+   point at `~/data/test_charts/massabesic_rgba.tif`). Confirm at run.
+
+## Estimated Scope
+
+Single small PR on `unh_marine_simulation` (`jazzy`). One file changed.

--- a/.agent/work-plans/issue-69/plan.md
+++ b/.agent/work-plans/issue-69/plan.md
@@ -54,14 +54,19 @@ already generic (parameterized by `robot_namespace`) and brings up
 | If we change... | Also update... | Included? |
 |---|---|---|
 | Sim now launches CAMP | Operator should stop running CAMP separately (avoid two instances) | Yes — documented in docstring |
-| `background_chart=''` passed to operator_ui/CAMP | Confirm CAMP tolerates an empty chart (else adjust) | Open Question 1 |
+| `background_chart=''` passed to operator_ui/CAMP | If CAMP rejects empty, fix CAMP's empty-tolerance (sibling PR on `rolker/camp`), not supply a chart | Open Question 1 |
 | Ben path | Must stay unaffected (only the bizzy entry changes) | Yes (separate file) |
 
 ## Open Questions
 
-1. Does `operator_ui_launch` / CAMP tolerate `background_chart=''` (no chart)?
-   If it errors on empty, fall back (omit the arg to use CAMP's own default, or
-   point at `~/data/test_charts/massabesic_rgba.tif`). Confirm at run.
+1. **Resolved (direction, per Roland):** pass `background_chart=''` (no chart). If
+   CAMP (`camp/CCOMAutonomousMissionPlanner`, which receives it as a positional
+   argv from `operator_ui_launch`) does NOT tolerate an empty background chart,
+   **fix the empty-tolerance in CAMP** rather than supplying a chart — the new
+   CAMP map code is removing background charts wholesale, so "no background chart"
+   is the correct long-term behavior. That fix would be a small cross-repo change
+   in `rolker/camp` (the original `camp/`, not the `camp2/` test framework). Tested
+   at implementation run; if a CAMP fix is needed it can be a sibling PR.
 
 ## Estimated Scope
 

--- a/.agent/work-plans/issue-69/progress.md
+++ b/.agent/work-plans/issue-69/progress.md
@@ -1,0 +1,17 @@
+---
+issue: 69
+---
+
+# Issue #69 — Sim: wire operator station (command_bridge_sender + CAMP) into bizzyboat_massabesic_launch
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-14 09:30 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Plan**: `.agent/work-plans/issue-69/plan.md` at `0b205e1`
+**PR**: https://github.com/rolker/unh_marine_simulation/pull/70 (`[PLAN]` prefix)
+**Phases**: single
+
+### Open questions
+- [ ] Does operator_ui_launch / CAMP tolerate background_chart='' (no chart)? If not, omit the arg (CAMP default) or use massabesic_rgba.tif.

--- a/marine_simulation/launch/bizzyboat_massabesic_launch.py
+++ b/marine_simulation/launch/bizzyboat_massabesic_launch.py
@@ -19,8 +19,11 @@ def generate_launch_description():
     costmap 0.5 m / 350 m — the 2026-06-12 field changes), so this reproduces the
     "planner won't plan beyond the local costmap" setup.
 
-    The operator/RViz station and bag recording (simulator_launch.py extras) are
-    not included here yet — run them separately or add as a follow-up.
+    Also brings up the operator station for `bizzy` (via sim_operator_launch):
+    `command_bridge_sender` (so CAMP's piloting-mode commands reach helm_manager)
+    and CAMP itself — no background chart, no RViz. Because this launches CAMP, do
+    NOT run a separate CAMP instance alongside it. Bag recording (a
+    simulator_launch.py extra) is still not included here.
     """
     mbes_grid_file = LaunchConfiguration('mbes_grid_file')
     mbes_grid_file_arg = DeclareLaunchArgument(
@@ -51,6 +54,27 @@ def generate_launch_description():
                 'sim_name': 'bizzy',
                 'enable_bridge': 'false',
                 'mbes_grid_file': mbes_grid_file,
+            }.items()
+        ),
+
+        # Operator station for bizzy (mirrors simulator_launch.py:103-123):
+        # command_bridge_sender (robot ns) + CAMP, on the one sim ROS graph, so
+        # CAMP's piloting-mode commands reach helm_manager. No udp_bridge needed
+        # (single domain), no background chart, no RViz.
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(
+                PathJoinSubstitution([
+                    FindPackageShare('marine_simulation'),
+                    'launch',
+                    'sim_operator_launch.py'
+                ])
+            ),
+            launch_arguments={
+                'robot_namespace': 'bizzy',
+                'operator_namespace': 'operator',
+                'enable_bridge': 'false',
+                'background_chart': '',
+                'rviz': 'false',
             }.items()
         ),
     ])


### PR DESCRIPTION
Closes #69

# Plan: Wire operator station (command_bridge_sender + CAMP) into bizzyboat_massabesic_launch

## Issue

https://github.com/rolker/unh_marine_simulation/issues/69

## Context

`bizzyboat_massabesic_launch.py` brings up the boat (autonomy + nav2 + asv_sim +
mbes) but not the operator side. The boat-side command chain runs
(`command_bridge_receiver`, `helm_manager`), but the **operator-side
`command_bridge_sender` is missing**, so CAMP's `send_command` is never converted
to `command` → the boat won't change piloting mode. `simulator_launch.py`
(`:95-123`) solves this for Ben by including `sim_operator_launch.py`, which is
already generic (parameterized by `robot_namespace`) and brings up
`operator_core_launch` (the sender, in the robot ns) + `operator_ui_launch` (CAMP).

## Approach

1. **Add a `sim_operator_launch` include** to `bizzyboat_massabesic_launch.py`,
   mirroring `simulator_launch.py:103-123` but for `bizzy`, with no chart / no RViz:
   - `robot_namespace='bizzy'`, `operator_namespace='operator'`, `enable_bridge='false'`,
     `background_chart=''`, `rviz='false'`.
   - Plain `IncludeLaunchDescription` (no `GroupAction`/`ROS_DOMAIN_ID` env — that
     block in `simulator_launch` only applies when `enable_bridge` is true).
2. **Update the docstring** — drop the "operator station … not included here yet"
   note; state that it now brings up the operator station (CAMP + command sender)
   on one ROS graph, so CAMP should not also be run separately.
3. **Verify** `--show-args` loads (operator includes resolve) and the Ben path
   (`simulator_launch`) is untouched.

## Files to Change

| File | Change |
|------|--------|
| `marine_simulation/launch/bizzyboat_massabesic_launch.py` | Add `sim_operator_launch` include for `bizzy` (no chart, no RViz); update docstring |

## Principles Self-Check

| Principle | Consideration |
|---|---|
| Reuse over duplication | Reuses the existing generic `sim_operator_launch.py`; no new config or forked operator launch. |
| Mirror surrounding code | Follows `simulator_launch.py`'s operator-include pattern exactly (the established convention). |
| Do it right / complete | Closes the full command path end-to-end; acceptance includes an actual CAMP→mode-switch test. |

## ADR Compliance

| ADR | Triggered | How addressed |
|---|---|---|
| (none) | No | Sim launch wiring; no ADR-governed area (store/datum/etc.) touched. |

## Consequences

| If we change... | Also update... | Included? |
|---|---|---|
| Sim now launches CAMP | Operator should stop running CAMP separately (avoid two instances) | Yes — documented in docstring |
| `background_chart=''` passed to operator_ui/CAMP | Confirm CAMP tolerates an empty chart (else adjust) | Open Question 1 |
| Ben path | Must stay unaffected (only the bizzy entry changes) | Yes (separate file) |

## Open Questions

1. Does `operator_ui_launch` / CAMP tolerate `background_chart=''` (no chart)?
   If it errors on empty, fall back (omit the arg to use CAMP's own default, or
   point at `~/data/test_charts/massabesic_rgba.tif`). Confirm at run.

## Estimated Scope

Single small PR on `unh_marine_simulation` (`jazzy`). One file changed.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
