### PR TITLE
Sim: parameterize asv_helm limits for echoboat240 (fix bizzy line-following)

### DIFF
--- a/asv_helm/src/asv_helm_node.cpp
+++ b/asv_helm/src/asv_helm_node.cpp
@@ -22,10 +22,19 @@ public:
   ASVHelm()
   :rclcpp_lifecycle::LifecycleNode("asv_helm")
   {
+    // Per-platform cmd_vel scaling. Defaults are the C-Worker/Ben (cw4) values;
+    // override for other hulls (e.g. echoboat240: 2.0 / 1.0) so cmd_vel maps to
+    // throttle/rudder against the boat's real limits — otherwise the open-loop
+    // rudder (rudder = -yaw/max_yaw_speed) saturates and line-following fails.
+    declare_parameter("max_speed", max_speed_);
+    declare_parameter("max_yaw_speed", max_yaw_speed_);
   }
-  
+
   CallbackReturn on_configure(const rclcpp_lifecycle::State& state) override
   {
+    max_speed_ = get_parameter("max_speed").as_double();
+    max_yaw_speed_ = get_parameter("max_yaw_speed").as_double();
+
     throttle_publisher_ = create_publisher<std_msgs::msg::Float32>("throttle",1);
     rudder_publisher_ = create_publisher<std_msgs::msg::Float32>("rudder",1);
     status_publisher_ = create_publisher<marine_interfaces::msg::Heartbeat>("marine/status/helm",1);

--- a/marine_simulation/launch/sim_robot_launch.py
+++ b/marine_simulation/launch/sim_robot_launch.py
@@ -174,6 +174,13 @@ def generate_launch_description():
                     ['/asv_sim', sim_name, 'have_commands']
                 )
             ),
+            # Scale cmd_vel -> throttle/rudder against the boat's real limits.
+            # asv_helm defaults to the cw4/Ben values (2.75 / 0.5); the
+            # EchoBoat 240 does ~2.0 m/s / ~1.0 rad/s (helm_manager in
+            # bizzyboat.yaml), so override for the bizzy platform — otherwise
+            # the open-loop rudder saturates and line-following fails.
+            SetParameter(name='max_speed', value=2.0, condition=is_bizzy),
+            SetParameter(name='max_yaw_speed', value=1.0, condition=is_bizzy),
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource(
                     PathJoinSubstitution([


### PR DESCRIPTION
Closes #71.

Parameterize asv_helm `max_speed`/`max_yaw_speed` (defaults 2.75/0.5 keep Ben unchanged) and override to 2.0/1.0 for the bizzy platform in sim_robot_launch, so cmd_vel maps to throttle/rudder against the EchoBoat 240 limits. Fixes the rudder saturation that broke line-following (bag analysis in the issue). asv_helm + marine_simulation build clean.

Needs a re-recorded sim line-follow to confirm cross-track drops / rudder no longer pinned.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
