### PR TITLE
Sim: yaw_inertia_coefficient + Lake Massabesic datum (echoboat240 line-following)

### DIFF
--- a/asv_sim/asv_sim/dynamics.py
+++ b/asv_sim/asv_sim/dynamics.py
@@ -243,9 +243,14 @@ class Dynamics(object):
 
             # let's oversimplify the asv to a thin disc
             # I = 1/2 * m * r^2
+            # The yaw_inertia_coefficient (default 1.0) scales this so
+            # the rotational response can be tuned independently of the
+            # forward mass; values below 1.0 shorten the yaw time
+            # constant (faster, less laggy turning).
 
             moment_of_inertia = (
-                self.model.mass
+                self.model.yaw_inertia_coefficient
+                * self.model.mass
                 * pow(self.model.rudder_distance, 2) / 2.0)
 
             angular_acceleration = torque / moment_of_inertia

--- a/asv_sim/asv_sim/model.py
+++ b/asv_sim/asv_sim/model.py
@@ -93,6 +93,14 @@ class Model:
             self.ns('rudder_coefficient'), 0.25,
             ParameterDescriptor(
                 description='Expresses rudder efficiency'))
+        node.declare_parameter(
+            self.ns('yaw_inertia_coefficient'), 1.0,
+            ParameterDescriptor(
+                description='Multiplier on the rotational moment of '
+                'inertia (jet model), decoupling yaw responsiveness '
+                'from forward mass. 1.0 keeps the thin-disc default; '
+                'values below 1.0 shorten the yaw time constant so the '
+                'boat reaches its commanded turn rate faster.'))
 
         node.declare_parameter(
             self.ns('thrust_noise'), 0.1,
@@ -169,6 +177,8 @@ class Model:
             if param.name == self.ns('rudder_coefficient'):
                 self.rudder_coefficient = param.value
                 need_update = True
+            if param.name == self.ns('yaw_inertia_coefficient'):
+                self.yaw_inertia_coefficient = param.value
             if param.name == self.ns('thrust_noise'):
                 self.thrust_noise = param.value
                 need_update = True

--- a/asv_sim/config/bizzyboat.yaml
+++ b/asv_sim/config/bizzyboat.yaml
@@ -16,3 +16,17 @@ asv_sim:
     # params (not per-platform); loading this file zeroes the current.
     environment.current.speed: 0.0
     environment.current.noise.speed: 0.0
+
+    # Lake Massabesic datum — a freshwater lake, not a tidal harbor. The
+    # asv_sim Environment defaults to Portsmouth Harbor (ellipsoid_to_mllw
+    # -28.104, msl_above_mllw 1.43, M2/N2/S2 tide), and the Massabesic launch
+    # doesn't load environment.yaml, so without these overrides the lake
+    # surface would sit at the wrong height and swing ~±1.5 m with a phantom
+    # tide. Zero the tidal harmonics (no tide on a lake) and fold the whole
+    # static height into ellipsoid_to_mllw so getEllipsoidalAltitude() returns
+    # a constant 52.3 m — the estimated WGS84 ellipsoidal water-surface height
+    # (matches the boat's GPS altitude). This is what the datum chain consumes
+    # as z(map_tide) for costmap alignment / bathy clearance.
+    environment.tide.constituents.amplitudes: [0.0, 0.0, 0.0]
+    environment.tide.ellipsoid_to_mllw: 52.3
+    environment.tide.msl_above_mllw: 0.0

--- a/asv_sim/config/echoboat240.yaml
+++ b/asv_sim/config/echoboat240.yaml
@@ -18,6 +18,10 @@
 #   launch accel (v~=0)  ~= max_force / mass            -> tuned to ~0.6 m/s^2
 #   go_straight_coefficient = max_force*sin(max_rudder_angle) / max_turn_rate
 #       -> full-throttle + full-steer settles at max_turn_rate
+#   yaw time constant    ~= yaw_inertia_coefficient * mass * rudder_distance
+#                             / (2 * go_straight_coefficient)
+#       -> how FAST the boat reaches its commanded turn rate (responsiveness),
+#          tunable independently of mass and of the steady-state turn rate
 #
 # KNOWN MODEL LIMITATION: drag_coefficient is bound to max_force/max_speed^3, so
 # matching top speed (1.9) AND launch accel (0.6) fixes the cubic drag curve and
@@ -49,11 +53,16 @@ asv_sim:
     models.echoboat240.mass:                190.0    # ~159 kg bare hull + M3/batteries/sensors (operating estimate)
 
     # --- Steering / yaw (vectored) ---
-    models.echoboat240.max_rudder_angle:    33.0     # full steering deflection (deg)
+    models.echoboat240.max_rudder_angle:    45.0     # full vectored deflection (deg); more reflective of the 240's thrust steering than the 33 datasheet rudder figure
     models.echoboat240.max_rudder_change_rate: 60.0  # steering slews quickly (vectored, not a rudder)
-    models.echoboat240.max_turn_rate:       57.0     # deg/s ~= 1.0 rad/s (helm yaw cap; ~0.9 rad/s pivot observed)
+    models.echoboat240.max_turn_rate:       57.0     # deg/s ~= 1.0 rad/s (helm yaw cap; ~0.9 rad/s pivot observed); steady-state turn rate only — responsiveness is set by yaw_inertia_coefficient
     models.echoboat240.rudder_distance:     1.0      # CoG -> thruster, m (2.4 m hull)
     models.echoboat240.rudder_coefficient:  0.25     # prop-branch only (unused for jet)
+    # Yaw responsiveness, decoupled from forward mass (see #73). The thin-disc
+    # inertia (mass*rudder_distance^2/2) gave the 240 a ~0.8 s yaw lag that drove a
+    # line-following limit cycle; 0.3 shortens the yaw time constant to ~0.25 s so
+    # corrections land in phase. 1.0 = unscaled thin-disc default (other platforms).
+    models.echoboat240.yaw_inertia_coefficient: 0.3
 
     # --- Disturbance noise (defaults) ---
     models.echoboat240.thrust_noise:        0.1


### PR DESCRIPTION
Closes #73

Two changes for the BizzyBoat–Massabesic (non-Gazebo) sim, validated live on
the water by Roland.

## 1. `yaw_inertia_coefficient` (asv_sim) — the headline fix

The jet model derived rotational inertia straight from forward mass
(`I = mass·rudder_distance²/2`), so yaw responsiveness couldn't be tuned
independently of forward acceleration or the moment arm. This baked a ~1 s
yaw lag into echoboat240 that drove a sustained line-following limit cycle
(~7.4 s period, ±2–3 m cross-track) — the controller wasn't saturated
(crab output only ~3 % at the ±90° clamp); cross-correlation showed actual
yaw lagging commanded yaw by ~1.0 s, matching the computed τ ≈ 0.8 s.

Add an optional `yaw_inertia_coefficient` (default **1.0** → no behavior
change for Ben / cw4 / drix) that multiplies the moment of inertia. The
three yaw levers are now independent:

| Lever | Controls |
|---|---|
| `mass` | forward acceleration only |
| `max_turn_rate` (→ `go_straight_coefficient`) | steady-state turn rate |
| **`yaw_inertia_coefficient`** (new) | yaw responsiveness / lag |

echoboat240 tuned to **0.3** (τ ≈ 0.25 s) so corrections land in phase; with
responsiveness decoupled, `max_turn_rate` stays at 57. Also set
`max_rudder_angle` 33 → 45 to reflect the 240's vectored-thrust steering.

## 2. Lake Massabesic datum (bizzyboat.yaml)

The Massabesic launch never loads `environment.yaml`, so the sim ran the
asv_sim **Portsmouth Harbor** defaults — wrong ellipsoidal height and a
phantom M2/N2/S2 tide swinging the surface ±1.5 m. Override in
`bizzyboat.yaml`: zero the tidal harmonics (no tide on a lake) and fold the
static height into `ellipsoid_to_mllw` so `getEllipsoidalAltitude()` is a
constant **52.3 m** — the estimated WGS84 ellipsoidal water-surface height
the datum chain consumes as `z(map_tide)` for costmap alignment / bathy
clearance.

## Companion
Builds on #71 (per-platform `asv_helm` cmd_vel scaling), merged into `jazzy`
first; both were needed for echoboat240 line-following.

## Testing
Built (`asv_sim`, `asv_helm`) and run in the Massabesic sim; line-following
hunting collapses and the lake surface holds at 52.3 m. Default-1.0 keeps
all other platforms unchanged.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
