### PR TITLE
fix(asv_sim): Massabesic sim datum 52.3 → 48.88 m full-pool ellipsoidal (#78)

### DIFF
--- a/asv_sim/config/bizzyboat.yaml
+++ b/asv_sim/config/bizzyboat.yaml
@@ -24,9 +24,13 @@ asv_sim:
     # surface would sit at the wrong height and swing ~±1.5 m with a phantom
     # tide. Zero the tidal harmonics (no tide on a lake) and fold the whole
     # static height into ellipsoid_to_mllw so getEllipsoidalAltitude() returns
-    # a constant 52.3 m — the estimated WGS84 ellipsoidal water-surface height
-    # (matches the boat's GPS altitude). This is what the datum chain consumes
-    # as z(map_tide) for costmap alignment / bathy clearance.
+    # a constant 48.88 m — the full-pool WGS84 ellipsoidal water-surface height.
+    # This is the single source of truth defined for the real boat in
+    # unh_echoboats_project11/bizzyboat_project11/config/massabesic_datum_polygons.yaml
+    # (chart_datum_z: 48.88); the sim must match it so z(map_tide) — consumed by
+    # the datum chain for costmap alignment / bathy clearance — agrees with the
+    # field. (Cross-checked: the NH GRANIT contour chart prior and the M3 survey
+    # draft agree to ~4 cm in mean ellipsoidal height at this datum.)
     environment.tide.constituents.amplitudes: [0.0, 0.0, 0.0]
-    environment.tide.ellipsoid_to_mllw: 52.3
+    environment.tide.ellipsoid_to_mllw: 48.88
     environment.tide.msl_above_mllw: 0.0


### PR DESCRIPTION
## What

Updates the Lake Massabesic **sim** water-surface datum in
`asv_sim/config/bizzyboat.yaml` from `ellipsoid_to_mllw: 52.3` to **48.88 m**,
matching the real-boat full-pool chart datum (the single source of truth in
`unh_echoboats_project11/.../massabesic_datum_polygons.yaml`, `chart_datum_z: 48.88`).
Also rewrites the comment to cite that source of truth instead of "estimated 52.3 m".

## Why

The sim surface sat **3.42 m too high** vs. the field. `getEllipsoidalAltitude()`
returns this constant as `z(map_tide)`, which the datum chain consumes for costmap
alignment / bathy clearance — so the error fed sim depth-aware planning and any
sim-vs-real bathy comparison.

Cross-check: ingesting the NH GRANIT contour chart prior into the bathymetry store
with `offset = 48.88` gives a mean ellipsoidal height of 43.64 m, matching the
independently-produced M3 survey draft mean (43.68 m) to ~4 cm. 52.3 left a 3.4 m
bias.

## Scope

- Only `bizzyboat.yaml` carried the Massabesic value. `environment.yaml`'s
  `-28.104` is the Portsmouth Harbor default (left untouched); `echoboat240.yaml`
  has no datum override.
- Config-only change; harmonics stay zeroed (no tide on a lake), `msl_above_mllw`
  stays `0.0`.

Closes #78

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
