### PR TITLE
Remove raster background-chart plumbing repo-wide (CAMP OSM base map)

### DIFF
--- a/.agent/work-plans/issue-80/progress.md
+++ b/.agent/work-plans/issue-80/progress.md
@@ -1,0 +1,22 @@
+---
+issue: 80
+---
+
+# Issue #80 — remove raster background-chart plumbing repo-wide (CAMP OSM base map)
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-07-30 14:21 -04:00
+**By**: Claude Code Agent (Claude Fable 5)
+**Verdict**: approved
+
+**Branch**: feature/issue-80 at `4913652`
+**Mode**: pre-push
+**Depth**: Light (reason: 5 files, 32 pure deletions, launch-config only)
+**Must-fix**: 0 | **Suggestions**: 0
+**Round**: 1 | **Ship**: recommended — pure deletion verified complete; no dangling refs, no orphaned imports
+
+### Findings
+- [ ] No issues found. LGTM.
+
+Static analysis: F401 AnyLaunchDescriptionSource in vrx operator_launch.py is pre-existing (unused before this change). Local Adversarial: off (user request). Note: sim_operator_launch no longer hard-depends on camp share dir at description time.

--- a/marine_simulation/launch/bizzyboat_massabesic_launch.py
+++ b/marine_simulation/launch/bizzyboat_massabesic_launch.py
@@ -73,7 +73,6 @@ def generate_launch_description():
                 'robot_namespace': 'bizzy',
                 'operator_namespace': 'operator',
                 'enable_bridge': 'false',
-                'background_chart': '',
                 'rviz': 'false',
             }.items()
         ),

--- a/marine_simulation/launch/gazebo_simulator_launch.py
+++ b/marine_simulation/launch/gazebo_simulator_launch.py
@@ -56,15 +56,10 @@ from lifecycle_msgs.msg import Transition
 
 def generate_launch_description():
     namespace = LaunchConfiguration('namespace')
-    background_chart = LaunchConfiguration('background_chart')
     enable_bridge = LaunchConfiguration('enable_bridge')
 
     namespace_arg = DeclareLaunchArgument(
         'namespace', default_value=TextSubstitution(text='ben'))
-    background_chart_arg = DeclareLaunchArgument(
-        'background_chart', default_value=PathJoinSubstitution(
-            [FindPackageShare('camp'), 'workspace', '13283', '13283_2.KAP']
-        ))
     enable_bridge_arg = DeclareLaunchArgument(
         'enable_bridge', default_value=TextSubstitution(text='false'))
 
@@ -146,7 +141,6 @@ def generate_launch_description():
             'robot_namespace': namespace,
             'operator_namespace': 'operator',
             'enable_bridge': enable_bridge,
-            'background_chart': background_chart,
             'use_sim_time': 'true',
             'rviz': 'true',
             'rviz_configuration': PathJoinSubstitution([
@@ -159,7 +153,6 @@ def generate_launch_description():
 
     return LaunchDescription([
         namespace_arg,
-        background_chart_arg,
         enable_bridge_arg,
         gazebo_ben,
         ben_core,

--- a/marine_simulation/launch/sim_operator_launch.py
+++ b/marine_simulation/launch/sim_operator_launch.py
@@ -45,7 +45,6 @@ def generate_launch_description():
     robot_namespace = LaunchConfiguration('robot_namespace')
     operator_namespace = LaunchConfiguration('operator_namespace')
     enable_bridge = LaunchConfiguration('enable_bridge')
-    background_chart = LaunchConfiguration('background_chart')
     use_sim_time = LaunchConfiguration('use_sim_time')
     rviz = LaunchConfiguration('rviz')
     rviz_configuration = LaunchConfiguration('rviz_configuration')
@@ -56,13 +55,6 @@ def generate_launch_description():
     operator_namespace_arg = DeclareLaunchArgument(
         'operator_namespace',
         default_value=TextSubstitution(text='operator')
-    )
-    background_chart_arg = DeclareLaunchArgument(
-        'background_chart',
-        default_value=PathJoinSubstitution([
-            get_package_share_directory('camp'),
-            'workspace', '13283', '13283_2.KAP'
-        ])
     )
     enable_bridge_arg = DeclareLaunchArgument(
         'enable_bridge', default_value=TextSubstitution(text='false')
@@ -109,7 +101,6 @@ def generate_launch_description():
         ),
         launch_arguments={
             'namespace': operator_namespace,
-            'background_chart': background_chart,
             'rviz': rviz,
             'rviz_configuration': rviz_configuration
         }.items()
@@ -125,7 +116,6 @@ def generate_launch_description():
     return LaunchDescription([
         robot_namespace_arg,
         operator_namespace_arg,
-        background_chart_arg,
         enable_bridge_arg,
         use_sim_time_arg,
         rviz_arg,

--- a/marine_simulation/launch/simulator_launch.py
+++ b/marine_simulation/launch/simulator_launch.py
@@ -47,16 +47,9 @@ from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
-    background_chart = LaunchConfiguration('background_chart')
     enable_bridge = LaunchConfiguration('enable_bridge')
     record_bag = LaunchConfiguration('record_bag')
     bag_directory = LaunchConfiguration('bag_directory')
-
-    background_chart_arg = DeclareLaunchArgument(
-        'background_chart', default_value=PathJoinSubstitution(
-            [FindPackageShare('camp'), 'workspace', '13283', '13283_2.KAP']
-        )
-    )
 
     enable_bridge_arg = DeclareLaunchArgument(
         'enable_bridge', default_value=TextSubstitution(text='false')
@@ -112,7 +105,6 @@ def generate_launch_description():
                     'robot_namespace': 'ben',
                     'operator_namespace': 'operator',
                     'enable_bridge': 'false',
-                    'background_chart': background_chart,
                     'rviz': 'true',
                     'rviz_configuration': PathJoinSubstitution([
                         FindPackageShare('ben_project11'),
@@ -152,7 +144,6 @@ def generate_launch_description():
     )
 
     return LaunchDescription([
-        background_chart_arg,
         enable_bridge_arg,
         record_bag_arg,
         bag_directory_arg,

--- a/vrx_project11/launch/operator_launch.py
+++ b/vrx_project11/launch/operator_launch.py
@@ -25,10 +25,6 @@ def generate_launch_description():
             "robot_namespace",
             default_value=TextSubstitution(text="wamv")
         ),
-        DeclareLaunchArgument(
-            "background_chart",
-            default_value=PathJoinSubstitution([ FindPackageShare('camp'), 'workspace','australia', 'SydneyInternationalRegattaCenter.pdf'])
-        ),
         SetParameter(
             name='use_sim_time',
             value=True
@@ -54,7 +50,6 @@ def generate_launch_description():
                     launch_arguments={
                         'namespace': namespace,
                         'robot_namespace': robot_namespace,
-                        'background_chart': LaunchConfiguration('background_chart'),
                     }.items()
                 ),
             ]


### PR DESCRIPTION
Closes #80.

## What

Removes all `background_chart` declarations and passthroughs from this repo —
pure deletion, 32 lines across five launch files:

- `marine_simulation/launch/sim_operator_launch.py`
- `marine_simulation/launch/simulator_launch.py`
- `marine_simulation/launch/gazebo_simulator_launch.py`
- `marine_simulation/launch/bizzyboat_massabesic_launch.py` (passed `''`)
- `vrx_project11/launch/operator_launch.py`

CAMP provides an OSM base map; the companion PR
rolker/unh_marine_autonomy#285 (rolker/unh_marine_autonomy#284) removes the
argument from the include target `operator_ui_launch.py`.

## Ordering

Safe to merge before or after the companion PR: undeclared launch arguments
passed to an included launch description are silently ignored, so neither
order breaks. The raster only fully stops loading once #285 lands.

## Notes

- `sim_operator_launch.py` previously resolved `get_package_share_directory('camp')`
  eagerly in the deleted default — that hard dependency at description time is
  gone as a side effect.
- Historical references in `.agent/work-plans/issue-69/` are planning records,
  intentionally untouched.

## Test plan

- `python3 -m py_compile` clean on all five files.
- `ros2 launch --print` on `sim_operator_launch.py`: no errors, includes reference
  no chart argument.
- Repo-wide grep: zero `background_chart` references left in launch code.
- Pre-push review (Light tier): 0 must-fix, 0 suggestions.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Fable 5`
